### PR TITLE
Don't rely on app for container or volume create

### DIFF
--- a/lib/containers/CreateContainer.component.js
+++ b/lib/containers/CreateContainer.component.js
@@ -229,7 +229,7 @@ export default class CreateContainer extends React.Component {
   }
 
   render() {
-    const { app, component } = this.props
-    return app && component ? this.resourcesFound() : <NotFound />
+    const { component } = this.props
+    return component ? this.resourcesFound() : <NotFound />
   }
 }

--- a/lib/shared/FeedbackInput.component.js
+++ b/lib/shared/FeedbackInput.component.js
@@ -14,7 +14,7 @@ const FeedbackInput = ({ prompt, type, value, ...rest }) =>
          { ...rest } />
 
 FeedbackInput.propTypes = {
-  prompt: React.PropTypes.string.isRequired,
+  prompt: React.PropTypes.string,
   type: React.PropTypes.string.isRequired,
   value: React.PropTypes.object.isRequired
 }

--- a/lib/volumes/CreateVolume.component.js
+++ b/lib/volumes/CreateVolume.component.js
@@ -130,8 +130,8 @@ export default class CreateVolume extends React.Component {
   }
 
   render() {
-    const { app, component } = this.props
+    const { component } = this.props
 
-    return app && component ? this.resourcesFound() : <NotFound />
+    return component ? this.resourcesFound() : <NotFound />
   }
 }


### PR DESCRIPTION
Turns out we were erroneously demanding that an app resource be present
in order to create a container or volume.  That behavior isn't strictly
necessary, so this commit removes it.