### PR TITLE
Volume size should normalize to a number.

### DIFF
--- a/lib/reducers.js
+++ b/lib/reducers.js
@@ -36,7 +36,8 @@ function form(state = fromJS({}), action) {
       'ports[].number': isNumber,
       'ports[].external_number': isNumber,
       'ports[].public': value => value && !!value
-    }
+    },
+    volumes: { size: isNumber }
   })
 
   return fromJS(reducer(fromJS(state).toJS(), action))


### PR DESCRIPTION
Go doesn't accept string values for number fields.  Because of that, we
want to ensure that any numeric value which gets handed to an API is, in
fact, a number.  Volumes had missed that on volume size, so this commit
should fix that.