### PR TITLE
Be tolerant of absent releases in summary.

### DIFF
--- a/lib/releases/ReleaseSummary.component.js
+++ b/lib/releases/ReleaseSummary.component.js
@@ -17,11 +17,12 @@ export default class ReleaseSummary extends React.Component {
   resourcesFound() {
     const { current, releasesUri, target } = this.props
     const latest = current.get('created') ? current : target
+    const created = latest.get('created') || ''
 
     return(
       <span>
         <h3>
-          { latest.get('created').split(' ').slice(0, 3).join(' ') }
+          { created.split(' ').slice(0, 3).join(' ') }
         </h3>
         { latest === current && (<p className='text-note'>Latest release</p>) }
         {


### PR DESCRIPTION
The ReleaseSummary react component was crashing in cases where there was
neither a current nor target release for it to pull.  The cause of this
seemed to be the fact that we were attempting to call `split` on an
undefined value, expecting a string.

This commit ensures that the value being split is a string, and so nulls
in this specific instance are being tolerated a little more.