### PR TITLE
Streamline of travis/docker build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ install:
 
 script:
   - npm test
-
-after_success:
-  - rm -r node_modules
-  - istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --opts mocha.opts && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js --verbose && rm -rf ./coverage
+  - rm -rf node_modules
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
   - export REPO=supergiant/supergiant-dashboard
   - export TAG=`if [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; elif [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" != "master" ]; then echo "unstable-${TRAVIS_BRANCH}"; else echo $TRAVIS_TAG ; fi`
   - docker build -t $REPO:$TAG .
-  - docker push $REPO
+
+after_success:
+  - istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --opts mocha.opts && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js --verbose && rm -rf ./coverage
+  - docker push $REPO:$TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM mhart/alpine-node:5.10
 
 ADD . .
-RUN apk add --no-cache make gcc g++ python
-RUN npm install
+RUN apk add --no-cache git make gcc g++ python
+RUN rm -rf node_modules && npm install
 
 # Default ENV
 ENV NODE_ENV=production


### PR DESCRIPTION
This change adds some build deps for npm install to the
Docker file, and reorders the travis config to place Docker
build as part of the test pass. It also places the coveralls
reporting to the post success section because the coverage api
appears to be not always 100% reliable for the coveralls nodejs
client.