### PR TITLE
Serialize release assets to components.

### DIFF
--- a/lib/apps/apps.entity.js
+++ b/lib/apps/apps.entity.js
@@ -22,7 +22,6 @@ export class App {
   }
 
   id() { return this.name }
-  tags() { return this.tags.toJS() }
   toJS() { return this.toMap().toJS() }
   toMap() { return fromJS({ name: this.name, tags: this.tags }) }
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -67,7 +67,7 @@ export function deleteResource(resource) {
 
 export function updateResource(resource) {
   return async (id, params) => {
-    let method   = `PATCH`
+    let method   = `PUT`
     let body     = JSON.stringify(params)
     let request  = { method, body }
     let response = await fetch(`/api/${resource}/${id}`, request)

--- a/lib/components/ComponentDetail.component.js
+++ b/lib/components/ComponentDetail.component.js
@@ -61,6 +61,7 @@ export default class ComponentDetail extends React.Component {
 
           <div className='context-menu'>
             <ReleasesDiff app={ app } component={ component } />
+
             <button className='with-glyph glyph-binary-action-color'>
               Restart
             </button>

--- a/lib/components/ComponentDetail.container.js
+++ b/lib/components/ComponentDetail.container.js
@@ -1,9 +1,9 @@
 import { fromJS } from 'immutable'
 import { connect } from 'react-redux'
 import { get as fetchApp } from '../apps/apps.actions'
-import { remove, get as fetchComponent } from './components.actions'
+import { remove, get as fetchComponent, update } from './components.actions'
 import ComponentDetail from './ComponentDetail.component'
-import { getApp, getComponent, } from '../selectors'
+import { getApp, getComponent } from '../selectors'
 
 function mapStateToProps(state, props) {
   const app = getApp(state, props)

--- a/lib/components/components.actions.js
+++ b/lib/components/components.actions.js
@@ -18,9 +18,11 @@ export const Destroy = "components:destroy"
 
 export const fetch = (appName) => ({ type: Fetch, appName })
 export const get = (id, appName) => ({ type: Get, id, appName })
-export const create = (params) => ({ type: Create, params })
+export const create = (params, appName) => ({ type: Create, params, appName })
 export const destroy = (id, appName) => ({ type: Destroy, id, appName })
-export const update = (id, params) => ({ type: Update, id, params })
+export const update = (id, appName, params) => (
+  { type: Update, appName, id, params }
+)
 
 export const Remove = "components:remove"
 export const Insert = "components:insert"
@@ -32,7 +34,5 @@ export const deploy = (id, appName, containers, volumes) => (
   { type: Deploy, id, appName, containers, volumes }
 )
 
-export const AddContainer = "components:containers:add"
-export const addContainer = (name, container) => (
-  { type: AddContainer, container }
-)
+export const Commit = "components:commit"
+export const commit = (id, appName) => ({ type: Commit, id, appName })

--- a/lib/components/components.entity.js
+++ b/lib/components/components.entity.js
@@ -8,6 +8,9 @@ export const deleteComponent = (appName, id) =>
 export const getComponent = (appName, id) =>
   new ResourceClient(componentRoute(appName)).get(id)
 
+export const updateComponent = (appName, id, params) =>
+  new ResourceClient(componentRoute(appName)).update(id, params)
+
 export const getComponents = (appName) =>
   new ResourceClient(componentRoute(appName)).fetch()
 
@@ -34,14 +37,36 @@ export class Component {
     this.tags = fromJS(tags)
   }
 
+  containers() {
+    const raw = this.tags.get('containers') || "{}"
+    try {
+      return JSON.parse(raw)
+    } catch(error) {
+      return {}
+    }
+  }
+
+  volumes() {
+    const raw = this.tags.get('volumes') || "{}"
+    try {
+      return JSON.parse(raw)
+    } catch(error) {
+      return {}
+    }
+  }
+
   id() { return this.name }
-  tags() { return this.tags.toJS() }
+
   toJS() { return this.toMap().toJS() }
+
   toMap() {
     return fromJS({
       name: kebabCase(this.tags.get('name')),
       tags: this.tags,
       id: this.name,
+      containers: this.containers(),
+      volumes: this.volumes(),
+      instance_number: this.tags.get('instance_number'),
       color: this.tags.get('color'),
       icon: this.tags.get('icon')
     })

--- a/lib/components/components.reducers.js
+++ b/lib/components/components.reducers.js
@@ -7,11 +7,6 @@ function components(state = fromJS({}), action) {
       return state.set(action.component.get('id'), action.component)
     case ComponentActions.Destroy:
       return state.delete(action.id)
-    case ComponentActions.Update:
-      return state.set(
-        action.id,
-        state.get(action.id).merge(fromJS(action.params))
-      )
     default:
       return state
   }

--- a/lib/components/components.sagas.js
+++ b/lib/components/components.sagas.js
@@ -1,11 +1,12 @@
 import { takeEvery } from 'redux-saga'
 import { call, fork, put } from 'redux-saga/effects'
 import { push } from 'react-router-redux'
+import { createAssetsSelector } from '../selectors'
 import * as ComponentEntity from './components.entity'
 import * as AppActions from '../apps/apps.actions'
 import * as ComponentActions from './components.actions'
-import * as DeploySagas from '../deploys/deploys.sagas'
-import * as ReleaseSagas from '../releases/releases.sagas'
+import * as ContainerActions from '../containers/containers.actions'
+import * as VolumeActions from '../volumes/volumes.actions'
 
 import {
   infoMessages,
@@ -29,6 +30,16 @@ function* getComponent({ id, appName }) {
   )
 
   let component = ComponentEntity.Component.from(body, appName).toMap()
+
+  for (let containerId in component.get('containers').toJS()) {
+    let container = component.getIn(['containers', containerId])
+    yield put(ContainerActions.insert(containerId, container))
+  }
+
+  for (let volumeId in component.get('volumes').toJS()) {
+    let volume = component.getIn(['volumes', volumeId])
+    yield put(VolumeActions.insert(volumeId, volume))
+  }
 
   yield put(ComponentActions.insert(component.get('id'), component))
 }
@@ -85,17 +96,56 @@ function* deleteComponent({ id, appName }) {
   }
 }
 
+function* updateComponent({ id, appName, params }) {
+  let { response, body } = yield call(
+    ComponentEntity.updateComponent,
+    appName,
+    id,
+    params
+  )
+
+  if (response.status === 202) {
+    yield put(ComponentActions.get(id, appName))
+  } else {
+    if (body.error) {
+      yield fork(errorMessages, body.error)
+    } else {
+      yield fork(errorMessages, body)
+    }
+  }
+}
+
 function* fetch() { yield takeEvery(ComponentActions.Fetch, fetchComponents) }
 function* get() { yield takeEvery(ComponentActions.Get, getComponent) }
 function* create() { yield takeEvery(ComponentActions.Create, createComponent) }
+function* update() { yield takeEvery(ComponentActions.Update, updateComponent) }
 
 function* destroy() {
   yield takeEvery(ComponentActions.Remove, deleteComponent)
 }
 
-export function* all() {
-  yield fork(fetch)
-  yield fork(get)
-  yield fork(create)
-  yield fork(destroy)
+function* commit(getState) {
+  yield takeEvery(ComponentActions.Commit, commitAssets, getState)
+}
+
+function* commitAssets(getState, { id, appName }) {
+  const selector = createAssetsSelector(appName, id)
+  const { containers, volumes } = selector(getState())
+  const params = {
+    tags: {
+      containers: JSON.stringify(containers.toJS()),
+      volumes: JSON.stringify(volumes.toJS())
+    }
+  }
+
+  yield put(ComponentActions.update(id, appName, params))
+}
+
+export function* all(getState) {
+  yield fork(fetch, getState)
+  yield fork(get, getState)
+  yield fork(create, getState)
+  yield fork(destroy, getState)
+  yield fork(update, getState)
+  yield fork(commit, getState)
 }

--- a/lib/containers/Container.container.js
+++ b/lib/containers/Container.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { remove } from './containers.actions'
+import { destroy as destroyContainer } from './containers.actions'
 import Container from './Container.component'
 
 function mapStateToProps(state, props) { return {} }
@@ -11,8 +11,8 @@ function mapDispatchToProps(dispatch, props) {
 
     event.preventDefault()
 
-    if (window.confirm("Are you sure you want to delete this container?")) {
-      dispatch(remove(id, container))
+    if (window.confirm("Are you sure you want to destroy this container?")) {
+      dispatch(destroyContainer(id, container.toJS()))
     }
   }
 

--- a/lib/containers/CreateContainer.container.js
+++ b/lib/containers/CreateContainer.container.js
@@ -3,9 +3,9 @@ import uuid from 'uuid'
 import { reduxForm } from 'redux-form'
 import { add } from '../notifications/notifications.actions'
 import { get } from '../components/components.actions'
-import { insert } from '../containers/containers.actions'
-import CreateContainer from './CreateContainer.component'
+import { create } from '../containers/containers.actions'
 import { createAppAndComponentSelector } from '../selectors.js'
+import CreateContainer from './CreateContainer.component'
 
 const fields = [
   'image',
@@ -59,7 +59,8 @@ function mapDispatchToProps(dispatch, props) {
       }
     } else {
       let id = uuid.v4()
-      dispatch(insert(id, { ...values, id, appName, componentName }))
+      let params = { ...values, id, appName, componentName }
+      dispatch(create(id, params))
     }
   }
 

--- a/lib/containers/containers.actions.js
+++ b/lib/containers/containers.actions.js
@@ -1,3 +1,9 @@
+export const Create = "containers:create"
+export const Destroy = "containers:destroy"
+
+export const create = (id, container) => ({ type: Create, id, container })
+export const destroy = (id, container) => ({ type: Destroy, id, container })
+
 export const Insert = "containers:insert"
 export const Remove = "containers:remove"
 

--- a/lib/containers/containers.sagas.js
+++ b/lib/containers/containers.sagas.js
@@ -1,18 +1,34 @@
 import { takeEvery } from 'redux-saga'
 import { call, fork, put } from 'redux-saga/effects'
 import { push } from 'react-router-redux'
+import * as ComponentActions from '../components/components.actions'
 import * as ContainerActions from './containers.actions'
 import { infoMessages } from '../notifications/notifications.sagas'
 
-function* addContainer({ container }) {
+function* commitContainer({ id, container }) {
   let { appName, componentName } = container
 
   yield fork(infoMessages, `Created container for ${container.image}`)
   yield put(push(`/apps/${appName}/components/${componentName}`))
+  yield put(ContainerActions.insert(id, container))
+  yield put(ComponentActions.commit(componentName, appName))
 }
 
-function* insert() { yield takeEvery(ContainerActions.Insert, addContainer) }
+function* dropContainer({ id, container }) {
+  let { appName, componentName } = container
+
+  yield fork(infoMessages, `Destroying container ${container.image}`)
+  yield put(ContainerActions.remove(id, container))
+  yield put(ComponentActions.commit(componentName, appName))
+}
+
+function* create() { yield takeEvery(ContainerActions.Create, commitContainer) }
+
+function* destroy() {
+  yield takeEvery(ContainerActions.Destroy, dropContainer)
+}
 
 export function* all() {
-  yield fork(insert)
+  yield fork(create)
+  yield fork(destroy)
 }

--- a/lib/entrypoints/entrypoints.entity.js
+++ b/lib/entrypoints/entrypoints.entity.js
@@ -26,7 +26,6 @@ export class Entrypoint {
   }
 
   id() { return this.domain }
-  tags() { return this.tags.toJS() }
   toJS() { return this.toMap().toJS() }
 
   toMap() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,5 +18,7 @@ let content = (
   </Provider>
 )
 
+window.dispatch = store.dispatch
+
 starfield()
 render(content, element)

--- a/lib/sagas.js
+++ b/lib/sagas.js
@@ -16,15 +16,15 @@ import * as ReleaseSagas from './releases/releases.sagas'
 import * as VolumeSagas from './volumes/volumes.sagas'
 
 export default function* root(getState) {
-  yield fork(AppSagas.all)
-  yield fork(ComponentSagas.all)
-  yield fork(ContainerSagas.all)
-  yield fork(DeploySagas.all)
-  yield fork(EntrypointSagas.all)
-  yield fork(InstanceSagas.all)
-  yield fork(NodeSagas.all)
-  yield fork(NotificationSagas.all)
-  yield fork(RegistrySagas.all)
-  yield fork(ReleaseSagas.all)
-  yield fork(VolumeSagas.all)
+  yield fork(AppSagas.all, getState)
+  yield fork(ComponentSagas.all, getState)
+  yield fork(ContainerSagas.all, getState)
+  yield fork(DeploySagas.all, getState)
+  yield fork(EntrypointSagas.all, getState)
+  yield fork(InstanceSagas.all, getState)
+  yield fork(NodeSagas.all, getState)
+  yield fork(NotificationSagas.all, getState)
+  yield fork(RegistrySagas.all, getState)
+  yield fork(ReleaseSagas.all, getState)
+  yield fork(VolumeSagas.all, getState)
 }

--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -7,12 +7,15 @@ export const getComponents = state => state.get('components')
 export const getNodes = state => state.get('nodes').toList()
 export const isFaded = state => state.getIn(['layouts', 'faded'])
 export const getNotifications = state => state.get('notifications').toList()
-export const getContainers = state => state.get('containers').toList()
-export const getVolumes = state => state.get('volumes').toList()
 export const getEntrypoints = state => state.get('entrypoints').toList()
 export const getRegistries = state => state.get('registries').toList()
 
+export const allContainers = state => state.get('containers')
+export const allVolumes = state => state.get('volumes')
 export const allInstances = state => state.get('instances')
+
+export const getContainers = state => allContainers(state).toList()
+export const getVolumes = state => allVolumes(state).toList()
 
 export const getAppInstances = (app) =>
   (state, props) =>
@@ -49,6 +52,22 @@ export const getComponent = (state, props) => {
 
     return state.get('components').get(key)
   }
+}
+
+export function createAssetsSelector(appName, componentName) {
+  const isApp = resource => resource.get('appName') === appName
+  const isComponent = resource =>
+    resource.get('componentName') === componentName
+
+  return createSelector(
+    allContainers,
+    allVolumes,
+    (containers, volumes) => {
+      const matchedContainers = containers.filter(isApp).filter(isComponent)
+      const matchedVolumes = volumes.filter(isApp).filter(isComponent)
+      return { containers: matchedContainers, volumes: matchedVolumes }
+    }
+  )
 }
 
 export function createContainerSelector(component) {

--- a/lib/store/local-storage.js
+++ b/lib/store/local-storage.js
@@ -3,6 +3,7 @@ import { fromJS } from 'immutable'
 const blacklist = [
   `apps`,
   `components`,
+  `containers`,
   `entrypoints`,
   `form`,
   `instances`,
@@ -10,6 +11,7 @@ const blacklist = [
   `nodes`,
   `releases`,
   `routing`,
+  `volumes`
 ]
 
 const notBlacklisted = (key, val) => !blacklist.includes(val)

--- a/lib/volumes/CreateVolume.container.js
+++ b/lib/volumes/CreateVolume.container.js
@@ -3,7 +3,7 @@ import uuid from 'uuid'
 import { reduxForm } from 'redux-form'
 import { add } from '../notifications/notifications.actions'
 import { get } from '../components/components.actions'
-import { insert } from '../volumes/volumes.actions'
+import { create } from '../volumes/volumes.actions'
 import { createAppAndComponentSelector } from '../selectors.js'
 import CreateVolume from './CreateVolume.component'
 
@@ -27,7 +27,6 @@ function mapStateToProps(state, props) {
   return { ...entities }
 }
 
-
 function mapDispatchToProps(dispatch, props) {
   const fetchResources = () =>
     dispatch(
@@ -46,7 +45,8 @@ function mapDispatchToProps(dispatch, props) {
       }
     } else {
       let id = uuid.v4()
-      dispatch(insert(id, { ...values, id, appName, componentName }))
+      let params = { ...values, id, appName, componentName }
+      dispatch(create(id, params))
     }
   }
 

--- a/lib/volumes/Volume.container.js
+++ b/lib/volumes/Volume.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { remove } from './volumes.actions'
+import { destroy as destroyVolume } from './volumes.actions'
 import Volume from './Volume.component'
 
 function mapStateToProps(state, props) { return {} }
@@ -11,8 +11,8 @@ function mapDispatchToProps(dispatch, props) {
 
     event.preventDefault()
 
-    if (window.confirm("Are you sure you want to delete this volume?")) {
-      dispatch(remove(id, volume))
+    if (window.confirm("Are you sure you want to destroy this volume?")) {
+      dispatch(destroyVolume(id, volume.toJS()))
     }
   }
 

--- a/lib/volumes/volumes.actions.js
+++ b/lib/volumes/volumes.actions.js
@@ -1,3 +1,9 @@
+export const Create = "volumes:create"
+export const Destroy = "volumes:destroy"
+
+export const create = (id, volume) => ({ type: Create, id, volume })
+export const destroy = (id, volume) => ({ type: Destroy, id, volume })
+
 export const Insert = "volumes:insert"
 export const Remove = "volumes:remove"
 

--- a/lib/volumes/volumes.sagas.js
+++ b/lib/volumes/volumes.sagas.js
@@ -1,18 +1,31 @@
 import { takeEvery } from 'redux-saga'
 import { call, fork, put } from 'redux-saga/effects'
 import { push } from 'react-router-redux'
+import * as ComponentActions from '../components/components.actions'
 import * as VolumeActions from './volumes.actions'
 import { infoMessages } from '../notifications/notifications.sagas'
 
-function* addVolume({ volume }) {
+function* commitVolume({ id, volume }) {
   let { appName, componentName } = volume
 
   yield fork(infoMessages, `Created volume for ${volume.name}`)
   yield put(push(`/apps/${appName}/components/${componentName}`))
+  yield put(VolumeActions.insert(id, volume))
+  yield put(ComponentActions.commit(componentName, appName))
 }
 
-function* insert() { yield takeEvery(VolumeActions.Insert, addVolume) }
+function* dropVolume({ id, volume }) {
+  let { appName, componentName } = volume
+
+  yield fork(infoMessages, `Destroying volume ${volume.name}`)
+  yield put(VolumeActions.remove(id, volume))
+  yield put(ComponentActions.commit(componentName, appName))
+}
+
+function* create() { yield takeEvery(VolumeActions.Create, commitVolume) }
+function* destroy() { yield takeEvery(VolumeActions.Destroy, dropVolume) }
 
 export function* all() {
-  yield fork(insert)
+  yield fork(create)
+  yield fork(destroy)
 }


### PR DESCRIPTION
Containers and volumes, up until this commit, were purely stored in
local storage.  Obviously this isn't a great long-term persistence
strategy and has no distribution prospects.

This commit hooks into container and volume creation/destruction a
marshaling process that records those assets on their parent component.

It turns out this was quite a long effort, and in the process a few
insights came up.

* I had overlooked the idea of using getState within sagas.  This is
  huge.  HUGE.  It means that much of the gymnastics I'm performing
  in the sagas and action creators (and thereby much of the UI itself)
  are bunk overwork.  So one day I'll go back and fix it, right?

* It's increasingly looking like assets should be persisted records on
  the API level.  Going to this level of contortion to get distributed
  data is rough.  Just simple persistence would remove all that baked
  in complexity.

* This whole time I've been treating Releases like a record, but while
  working on this I had an idea of instead treating them like a second
  state tree similar to the one core to Redux.  This would enable some
  sophisticated behavior "for free", just like Redux does: undo/redo,
  queueing, logging, etc.