### PR TITLE
Switch to hash history recording.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'
-import { Router, browserHistory } from 'react-router'
+import { Router, hashHistory } from 'react-router'
 import { syncHistoryWithStore } from 'react-router-redux'
 import Routes from './routes'
 import store from './store'
@@ -11,7 +11,7 @@ import { starfield } from './visuals/starfield'
 let element = document.getElementById('app')
 let router  = state => state.get('routing').toJS()
 let options = { selectLocationState: router }
-let history = syncHistoryWithStore(browserHistory, store, options)
+let history = syncHistoryWithStore(hashHistory, store, options)
 let content = (
   <Provider store={ store }>
     <Router history={ history } routes={ Routes } />

--- a/lib/store/development.js
+++ b/lib/store/development.js
@@ -2,7 +2,7 @@ import { fromJS } from 'immutable'
 import { applyMiddleware, compose, createStore } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 import { routerMiddleware } from 'react-router-redux'
-import { browserHistory } from 'react-router'
+import { hashHistory } from 'react-router'
 import { seed } from './seed'
 
 import { rehydrate } from './local-storage'
@@ -27,7 +27,7 @@ if (windowPresent && devToolsPresent) {
 
 const middleware = applyMiddleware(
   createSagaMiddleware(sagas),
-  routerMiddleware(browserHistory)
+  routerMiddleware(hashHistory)
 )
 
 const enhancer = compose(middleware, instrument)

--- a/lib/store/production.js
+++ b/lib/store/production.js
@@ -2,7 +2,7 @@ import { fromJS } from 'immutable'
 import { applyMiddleware, createStore } from 'redux'
 import { routerMiddleware } from 'react-router-redux'
 import createSagaMiddleware from 'redux-saga'
-import { browserHistory } from 'react-router'
+import { hashHistory } from 'react-router'
 import { rehydrate } from './local-storage'
 import { seed } from './seed'
 
@@ -13,7 +13,7 @@ let initializer = rehydrate(fromJS({}), seed.entities)
 
 const middleware = applyMiddleware(
   createSagaMiddleware(sagas),
-  routerMiddleware(browserHistory)
+  routerMiddleware(hashHistory)
 )
 
 const store = createStore(Supergiant, initializer, middleware)


### PR DESCRIPTION
The production version of the dashboard has to have a flexible URL
schema.  I'm not sure how to do dynamic root routing with
browserHistory, so for the time being we're going to use hashHistory.