### PR TITLE
Remove mock Omnibar

### DIFF
--- a/lib/layouts/Menu.component.js
+++ b/lib/layouts/Menu.component.js
@@ -17,9 +17,6 @@ export default class Menu extends React.Component {
           <Link to='/settings' className='menu-icon settings-icon' title='Settings' />
           <Link to='/nodes' className='menu-icon node-icon' title='Nodes' />
         </nav>
-        <div className='menu-omnibar'>
-          <Omnibar />
-        </div>
       </div>
     )
   }

--- a/lib/styles/sections/_menu.scss
+++ b/lib/styles/sections/_menu.scss
@@ -9,7 +9,7 @@
   height: 60px;
   padding: 12px 0 0;
   vertical-align: top;
-  width: 290px;
+  // width: 290px;
 
   .menu-icon {
     color: $base-white;
@@ -24,7 +24,7 @@
     width: 28px;
 
     &:first-child { margin-left: 0; }
-    &:last-child { margin-right: 0; }
+    // &:last-child { margin-right: 0; }
 
     &.app-logo {
       background: url(/images/supergiant.png) no-repeat 0 50%;
@@ -35,11 +35,13 @@
     &.settings-icon {
       background: url(/images/icon_settings.png) no-repeat 50% 50%;
       background-size: 24px auto;
+      float: right;
     }
 
     &.node-icon {
       background: url(/images/icon_node.svg) no-repeat 50% 50%;
       background-size: 24px auto;
+      float: right;
     }
   }
 }


### PR DESCRIPTION
It's a really great design, but it doesn't need to be part of the Dashboard
until it actually does stuff.

This commit removes the mock OmniBar from the header of the Dashboard.

![screen shot 2016-04-22 at 12 52 37 am](https://cloud.githubusercontent.com/assets/676428/14734032/b6f5bb2e-0824-11e6-8f94-6eeb55c6b587.png)
