### PR TITLE
App detail page should show app.

### DIFF
--- a/lib/apps/AppDetail.component.js
+++ b/lib/apps/AppDetail.component.js
@@ -29,7 +29,7 @@ export default class AppDetail extends React.Component {
             </button>
           </div>
         </header>
-
+        <App app={ app } />
         <div />
       </div>
     )


### PR DESCRIPTION
Previously the app detail page was just a way to delete an app entity
for development purposes.  We like the fact that it's there, now, though
its content was sparse.  This commit adds the app component to the page
so we can start building it out.