### PR TITLE
Release buttons should adapt to target states.

### DIFF
--- a/lib/releases/Releases.component.js
+++ b/lib/releases/Releases.component.js
@@ -39,7 +39,7 @@ export default class Releases extends React.Component {
           <div className='context-menu'>
 
             {
-              target && (
+              target.toList().count() > 0 && (
                 <button onClick={ deploy }
                         className='with-glyph glyph-deploy-action-color'>
                   Deploy
@@ -48,7 +48,7 @@ export default class Releases extends React.Component {
             }
 
             {
-              !target && (
+              target.toList().count() === 0 && (
                 <button className='with-glyph glyph-right-arrow-action-color'
                         onClick={ create }>
                   Prepare a deploy


### PR DESCRIPTION
In a release page, a Deploy button should be displayed if there is a
target release.  If there is no target release, then a prepare release
button should be displayed.