### PR TITLE
Generate correct docker keys from repo form.

### DIFF
--- a/lib/registries/CreateRegistry.component.js
+++ b/lib/registries/CreateRegistry.component.js
@@ -5,7 +5,6 @@ import { DockerConstellation } from '../visuals/dockerConstellation'
 export default class CreateRegistry extends React.Component {
   static propTypes = {
     submit: React.PropTypes.func.isRequired,
-    generateKey: React.PropTypes.func.isRequired,
     fields: React.PropTypes.shape({
       name: React.PropTypes.object.isRequired,
       password: React.PropTypes.object.isRequired,
@@ -19,7 +18,7 @@ export default class CreateRegistry extends React.Component {
 
   render() {
     const { submit, fields } = this.props
-    const { name, username, password } = fields
+    const { name, username, password, email } = fields
     return(
       <section>
         <header className='context-header'>
@@ -60,6 +59,12 @@ export default class CreateRegistry extends React.Component {
 
             <fieldset className='col-4'>
               <label className='easy'>Enter repository credentials.</label>
+
+              <label>
+                <FeedbackInput type='email'
+                               prompt='email'
+                               value={ email } />
+              </label>
 
               <label>
                 <FeedbackInput type='text'

--- a/lib/registries/CreateRegistry.container.js
+++ b/lib/registries/CreateRegistry.container.js
@@ -4,15 +4,34 @@ import { add } from '../notifications/notifications.actions'
 import { create } from '../registries/registries.actions'
 import CreateRegistry from './CreateRegistry.component'
 
-const generateKey = props => {
+const configFor = (auth, email) =>
+`{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "${auth}",
+			"email": "${email}"
+		}
+	}
+}`
+
+const generateAuth = props => {
   const { values } = props
   const { username, password } = values
 
   return new Buffer(`${username}:${password}`).toString(`base64`)
 }
 
+const generateKey = props => {
+  const { values } = props
+  const { email } = values
+  const auth = generateAuth(props)
+  const config = configFor(auth, email)
+
+  return new Buffer(config).toString(`base64`)
+}
+
 const form = 'registries'
-const fields = [ 'name', 'username', 'password' ]
+const fields = [ 'name', 'username', 'password', 'email' ]
 const getFormState = (state, mount) => state.get(mount).toJS()
 const validate = (values) => {
   let errors = {}
@@ -21,6 +40,7 @@ const validate = (values) => {
   if (!values.name) { errors.name = `Name can't be blank` }
   if (!values.username) { errors.username = `Username can't be blank` }
   if (!values.password) { errors.password = `Password can't be blank` }
+  if (!values.email) { errors.email = `Email can't be blank` }
 
   return errors
 }


### PR DESCRIPTION
Turns out the repository (nee registry) create form was only generating
one of the fields required for the docker access key.  This commit
introduces the full functionality to the mix.

One problem during the development of this feature was the discovery
that a docker key is actually whitespace significant.  In other words,
there are some ugly methods in the create registry file which speak of
this constraint.