### PR TITLE
Add better friendly resource request/usage/limit indicators

### DIFF
--- a/lib/containers/CreateContainer.component.js
+++ b/lib/containers/CreateContainer.component.js
@@ -7,7 +7,9 @@ import ManageMounts from './ManageMounts.component'
 import ManagePorts from './ManagePorts.component'
 import NotFound from '../shared/NotFound.component'
 import { Link } from 'react-router'
+import { floatToDataUnits, floatFloorToPlaces } from '../shared/normalizers'
 import { CityOnPlanet } from '../visuals/cityOnPlanet'
+
 
 export default class CreateContainer extends React.Component {
   static propTypes = {
@@ -40,43 +42,6 @@ export default class CreateContainer extends React.Component {
     }
 
     this.backgroundCanvas = new CityOnPlanet(this.state.color)
-  }
-
-  miliCpuToUnits(num, floor=1) {
-    let number = parseFloat(num)
-
-    if (isNaN(number) || (num < floor)) return ''
-
-    return `${number / 1000 } CPU`
-  }
-
-  floatToDataUnits(num, floor=1) {
-    let number  = parseFloat(num)
-    let units   = 'KB'
-    const oneKB = Math.pow(2, 10);
-    const oneMB = Math.pow(2, 20);
-    const oneGB = Math.pow(2, 30);
-    const oneTB = Math.pow(2, 40);
-
-    if (isNaN(number) || (number < floor)) return ''
-
-    if (num < oneMB) {
-      number = Math.round(num / oneKB * 100) / 100
-    }
-    else if (num >= oneMB && num < oneGB) {
-      number = Math.round(num / oneMB * 100) / 100
-      units = 'MB'
-    }
-    else if (num >= oneGB && num < oneTB) {
-      number = Math.round(num / oneGB * 100) / 100
-      units = 'GB'
-    }
-    else if (num >= oneTB) {
-      number = Math.round(num / oneTB * 100) / 100
-      units = 'TB'
-    }
-
-    return  `${number} ${units}`
   }
 
   componentWillReceiveProps(newProps) {
@@ -139,30 +104,33 @@ export default class CreateContainer extends React.Component {
               </aside>
 
               <fieldset className='col-4'>
-                <label className='easy'>Enter CPU values in thousanths.</label>
+                <label className='easy'>Enter CPU values in decimals.</label>
 
                 <div className='select-min-max row'>
                   <div className='col-6'>
                     <label>
                       Min
                       <FeedbackInput type='number'
-                                     min='1'
+                                     min='0'
+                                     prompt='ex: 0.125'
                                      className='easy'
                                      value={ cpu.min } />
                     </label>
                     <p className='text-note'>
-                      { this.miliCpuToUnits(cpu.min.value, 1) }
+                      { floatFloorToPlaces(cpu.min.value, 3) }
                     </p>
                   </div>
                   <div className='col-6'>
                     <label>
                       Max
                       <FeedbackInput type='number'
+                                     min='0'
+                                     prompt='ex: 0.5'
                                      className='easy'
                                      value={ cpu.max } />
                     </label>
                     <p className='text-note'>
-                      { this.miliCpuToUnits(cpu.max.value, 1) }
+                      { floatFloorToPlaces(cpu.max.value, 3) }
                     &nbsp;</p>
                   </div>
                 </div>
@@ -174,20 +142,22 @@ export default class CreateContainer extends React.Component {
                     <label>
                       Min
                       <FeedbackInput type='number'
+                                     min='0'
                                      value={ ram.min } />
                     </label>
                     <p className='text-note'>
-                      { this.floatToDataUnits(ram.min.value, 1) }
+                      { floatToDataUnits(ram.min.value) }
                     &nbsp;</p>
                   </div>
                   <div className='col-6'>
                     <label>
                       Max
                       <FeedbackInput type='number'
+                                     min='0'
                                      value={ ram.max } />
                     </label>
                     <p className='text-note'>
-                      { this.floatToDataUnits(ram.max.value, 1) }
+                      { floatToDataUnits(ram.max.value) }
                     &nbsp;</p>
                   </div>
                 </div>

--- a/lib/instances/Instance.component.js
+++ b/lib/instances/Instance.component.js
@@ -26,18 +26,6 @@ export default class Instance extends React.Component {
             <RamMeter usage={ instance.getIn(['ram', 'usage']) }
                       limit={ instance.getIn(['ram', 'limit']) } />
           </div>
-
-          <div className='row'>
-            <div className='icon icon-disk col-2' />
-            <p className='col-8'>
-              <span className='text-faded'>GP2 </span>
-            </p>
-          </div>
-
-          <div className='row'>
-            <DiskMeter usage={ instance.getIn(['disk', 'usage']) }
-                       limit={ instance.getIn(['disk', 'limit']) } />
-          </div>
         </li>
       </span>
     )

--- a/lib/nodes/Node.component.js
+++ b/lib/nodes/Node.component.js
@@ -34,11 +34,6 @@ const Node = ({ node }) =>
       <RamMeter usage={ node.getIn(['ram', 'usage']) }
                 limit={ node.getIn(['ram', 'limit']) } />
     </div>
-
-    <div className='row' style={{ display: 'none' }}>
-      <DiskMeter usage={ node.getIn(['disk', 'usage']) }
-                 limit={ node.getIn(['disk', 'limit']) } />
-    </div>
   </li>
 
 Node.propTypes = { node: React.PropTypes.object.isRequired }

--- a/lib/shared/CpuMeter.component.js
+++ b/lib/shared/CpuMeter.component.js
@@ -1,24 +1,24 @@
 import React from 'react'
+import { floatFloorToPlaces } from '../shared/normalizers'
 
 const CpuMeter = ({ usage, limit }) =>
   <span>
     <div className='status-meter with-label-right'
-         title={ `${ usage / 1000 } / ${ limit / 1000 } CPUs used`}
-
-    >
+         title={ `${ usage / 1000 } / ${ limit / 1000 } CPUs used`}>
       {
         (usage && limit) && (
           <div className='status-metric'
                title={ `${ usage / 1000 } CPU` }
                style={
                  { width: `${Math.round((usage / limit) * 100)}%` }
-               }>
-            { usage / 1000 }
-          </div>
+               } />
         )
       }
     </div>
     <div className='label-right'>CPU</div>
+    <p className='text-note row'>
+      { floatFloorToPlaces(usage / 1000) } used / { floatFloorToPlaces(limit / 1000) } CPU limit
+    </p>
   </span>
 
 export default CpuMeter

--- a/lib/shared/DiskMeter.component.js
+++ b/lib/shared/DiskMeter.component.js
@@ -1,33 +1,5 @@
 import React from 'react'
-
-function floatToDataUnits(num, floor=1) {
-  let number  = parseFloat(num)
-  let units   = 'KB'
-  const oneKB = Math.pow(2, 10);
-  const oneMB = Math.pow(2, 20);
-  const oneGB = Math.pow(2, 30);
-  const oneTB = Math.pow(2, 40);
-
-  if (isNaN(number) || (number < floor)) return ''
-
-  if (num < oneMB) {
-    number = Math.round(num / oneKB * 100) / 100
-  }
-  else if (num >= oneMB && num < oneGB) {
-    number = Math.round(num / oneMB * 100) / 100
-    units = 'MB'
-  }
-  else if (num >= oneGB && num < oneTB) {
-    number = Math.round(num / oneGB * 100) / 100
-    units = 'GB'
-  }
-  else if (num >= oneTB) {
-    number = Math.round(num / oneTB * 100) / 100
-    units = 'TB'
-  }
-
-  return  `${number} ${units}`
-}
+import { floatToDataUnits } from '../shared/normalizers'
 
 const DiskMeter = ({ usage, limit }) =>
   <span>

--- a/lib/shared/RamMeter.component.js
+++ b/lib/shared/RamMeter.component.js
@@ -1,33 +1,5 @@
 import React from 'react'
-
-function floatToDataUnits(num, floor=1) {
-  let number  = parseFloat(num)
-  let units   = 'KB'
-  const oneKB = Math.pow(2, 10);
-  const oneMB = Math.pow(2, 20);
-  const oneGB = Math.pow(2, 30);
-  const oneTB = Math.pow(2, 40);
-
-  if (isNaN(number) || (number < floor)) return ''
-
-  if (num < oneMB) {
-    number = Math.round(num / oneKB * 100) / 100
-  }
-  else if (num >= oneMB && num < oneGB) {
-    number = Math.round(num / oneMB * 100) / 100
-    units = 'MB'
-  }
-  else if (num >= oneGB && num < oneTB) {
-    number = Math.round(num / oneGB * 100) / 100
-    units = 'GB'
-  }
-  else if (num >= oneTB) {
-    number = Math.round(num / oneTB * 100) / 100
-    units = 'TB'
-  }
-
-  return  `${number} ${units}`
-}
+import { floatToDataUnits } from '../shared/normalizers'
 
 const RamMeter = ({ usage, limit }) =>
   <span>
@@ -38,13 +10,14 @@ const RamMeter = ({ usage, limit }) =>
           <div className='status-metric'
                style={
                  { width: `${Math.round((usage / limit) * 100)}%` }
-               }>
-            { floatToDataUnits(usage) }
-          </div>
+               } />
         )
       }
     </div>
     <div className='label-right'>RAM</div>
+    <p className='text-note row'>
+      { floatToDataUnits(usage || 0) } used / { floatToDataUnits(limit) } RAM limit
+    </p>
   </span>
 
 export default RamMeter

--- a/lib/shared/normalizers.js
+++ b/lib/shared/normalizers.js
@@ -1,0 +1,37 @@
+export function floatToDataUnits(num, decimalPlaces=2, floor=0) {
+  let number   = num
+  let units    = 'Ki'
+  const oneKi  = Math.pow(2, 10)
+  const oneMi  = Math.pow(2, 20)
+  const oneGi  = Math.pow(2, 30)
+  const oneTi  = Math.pow(2, 40)
+  const places = Math.pow(10, decimalPlaces)
+
+  if (isNaN(number) || (number < floor)) return '0'
+
+  if (num < oneMi) {
+    number = Math.round(num / oneKi * places) / places
+  }
+  else if (num >= oneMi && num < oneGi) {
+    number = Math.round(num / oneMi * places) / places
+    units = 'Mi'
+  }
+  else if (num >= oneGi && num < oneTi) {
+    number = Math.round(num / oneGi * places) / places
+    units = 'Gi'
+  }
+  else if (num >= oneTi) {
+    number = Math.round(num / oneTi * places) / places
+    units = 'Ti'
+  }
+
+  return  `${number} ${units}`
+}
+
+export function floatFloorToPlaces(num, decimalPlaces=2, floor=0) {
+  if (isNaN(num) || (num < floor)) return floor
+
+  const places = Math.pow(10, decimalPlaces)
+
+  return Math.round(num * places) / places
+}

--- a/lib/styles/modules/_data-display.scss
+++ b/lib/styles/modules/_data-display.scss
@@ -129,7 +129,7 @@ table.line-items {
   border-radius: 1em;
   display: block;
   height: 1.5em;
-  margin: 0 0 1em;
+  margin: 0.5em 0 0.5em;
 
   .status-metric {
     background-image: linear-gradient(180deg, #c7eeff, #9addff);
@@ -171,6 +171,7 @@ table.line-items {
   padding-left: 5%;
   font-size: 1.25em;
   line-height: 1;
+  margin: 0.5em 0 0;
 }
 
 


### PR DESCRIPTION
Due to a switch to friendlier resource notation in the API, this commit

- changes CPUs to decimal, instead of mili-
- adds unit descriptions to status meters