### PR TITLE
Fix App component name displays and background star

### DIFF
--- a/lib/apps/AppDetail.component.js
+++ b/lib/apps/AppDetail.component.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import App from './App.container'
 import NotFound from '../shared/NotFound.component'
-import { supergiant } from '../visuals/supergiant'
+import { BackgroundSupergiant } from '../visuals/supergiant'
 
 export default class AppDetail extends React.Component {
   static propTypes = {
@@ -10,9 +10,14 @@ export default class AppDetail extends React.Component {
     fetchApp: React.PropTypes.func.isRequired
   }
 
-  componentWillMount()   { this.props.fetchApp() }
-  componentDidMount()    { supergiant.start() }
-  componentWillUnmount() { supergiant.stop() }
+  componentWillMount()   {
+    this.props.fetchApp()
+
+    this.backgroundCanvas = new BackgroundSupergiant()
+  }
+
+  componentDidMount()    { this.backgroundCanvas.start() }
+  componentWillUnmount() { this.backgroundCanvas.stop() }
 
   resourcesFound() {
     const { deleteApp, app } = this.props

--- a/lib/apps/AppForm.component.js
+++ b/lib/apps/AppForm.component.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import FeedbackInput from '../shared/FeedbackInput.component'
-import { supergiant } from '../visuals/supergiant'
+import { BackgroundSupergiant } from '../visuals/supergiant'
 
 export default class AppForm extends React.Component {
   static propTypes = {
@@ -8,8 +8,12 @@ export default class AppForm extends React.Component {
     name: React.PropTypes.object.isRequired
   }
 
-  componentDidMount() { supergiant.start() }
-  componentWillUnmount() { supergiant.stop() }
+  componentWillMount()   {
+    this.backgroundCanvas = new BackgroundSupergiant()
+  }
+
+  componentDidMount()    { this.backgroundCanvas.start() }
+  componentWillUnmount() { this.backgroundCanvas.stop() }
 
   render() {
     const { name, submit } = this.props

--- a/lib/apps/Apps.component.js
+++ b/lib/apps/Apps.component.js
@@ -26,8 +26,10 @@ export default class Apps extends React.Component {
         </header>
 
         <div className='dashboard-apps'>
+          { apps.map((app, index) => <App key={ index } app={ app } />) }
+
           {
-            apps.count() < 1 && (
+            (apps.count() == 1) && (apps.get(0).name == 'supergiant') && (
               <div className='welcome-message'>
                 <h1>Welcome to Supergiant.</h1>
 
@@ -36,10 +38,8 @@ export default class Apps extends React.Component {
                   to manage stateful, distributed apps at any scale.
                 </p>
 
-                <br />
-
                 <p className='text-note'>
-                  It appears you don't have any apps,<br />
+                  It appears the only app running is the Supergiant dashboard,
                   so let's get started.
                 </p>
 
@@ -49,8 +49,6 @@ export default class Apps extends React.Component {
               </div>
             )
           }
-
-          { apps.map((app, index) => <App key={ index } app={ app } />) }
         </div>
       </section>
     )

--- a/lib/components/Component.component.js
+++ b/lib/components/Component.component.js
@@ -14,7 +14,7 @@ export default class Component extends React.Component {
         <div className='dashboard-list-item-planet'
              style={ { backgroundColor: component.get('color') } } />
         <figcaption className='with-glyph glyph-right-arrow-action-color'>
-          { component.get('name') }
+          { component.get('tags').get('name') }
         </figcaption>
       </figure>
     )

--- a/lib/components/ComponentDetail.component.js
+++ b/lib/components/ComponentDetail.component.js
@@ -57,7 +57,13 @@ export default class ComponentDetail extends React.Component {
     return(
       <div className='component'>
         <header className='context-header'>
-          <div className='context-title'>{ component.get('name') }</div>
+          <div className='context-title'>
+            {
+              component.get('tags').get('name')
+            } <span className='text-note font-size-reset'>
+              ({ component.get('name') })
+            </span>
+          </div>
 
           <div className='context-menu'>
             <ReleasesDiff app={ app } component={ component } />

--- a/lib/entrypoints/CreateEntrypoint.component.js
+++ b/lib/entrypoints/CreateEntrypoint.component.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import FeedbackInput from '../shared/FeedbackInput.component'
-import { supergiant } from '../visuals/supergiant'
+import { BackgroundSupergiant } from '../visuals/supergiant'
 
 
 export default class CreateEntrypoint extends React.Component {
@@ -11,8 +11,12 @@ export default class CreateEntrypoint extends React.Component {
     }).isRequired
   }
 
-  componentDidMount() { supergiant.start() }
-  componentWillUnmount() { supergiant.stop() }
+  componentWillMount()   {
+    this.backgroundCanvas = new BackgroundSupergiant()
+  }
+
+  componentDidMount()    { this.backgroundCanvas.start() }
+  componentWillUnmount() { this.backgroundCanvas.stop() }
 
   render() {
     const { submit, fields: { domain } } = this.props

--- a/lib/instances/AppInstanceStats.component.js
+++ b/lib/instances/AppInstanceStats.component.js
@@ -22,8 +22,8 @@ export default class AppInstanceStats extends React.Component {
     return(
       <span>
         <div className='app-detail-stat'>
-          <div>{ app.get('name') }</div>
-          <div className='text-note'>app-unique-name</div>
+          <div>{ app.get('tags').get('name') }</div>
+          <div className='text-note'>{ app.get('name') }</div>
         </div>
         <div className='app-detail-stat'>
           <div>

--- a/lib/styles/base/_typography.scss
+++ b/lib/styles/base/_typography.scss
@@ -90,7 +90,10 @@ picture {
 .code { font-family: monospace }
 
 .text-note { color: $text-diminished; }
+
 .text-faded { opacity: 0.67; }
+
+.font-size-reset { font-size: $base-font-size; }
 
 .text-left { text-align: left; }
 .text-right { text-align: right; }

--- a/lib/visuals/supergiant.js
+++ b/lib/visuals/supergiant.js
@@ -1,25 +1,51 @@
 import { drawParticles, Particle } from './Particle'
 
-class Supergiant {
+export class BackgroundSupergiant {
   constructor() {
-    let amount = 300
-    let radius = () => window.innerHeight / 2
-    let location = () => ({ x: window.innerWidth / 2, y: window.innerHeight })
-    let speed = () => {
-      let value = Math.random() * 0.5
-
-      return Math.round(Math.random()) === 0 ? value : value * -1
-    }
-
-    this.id = null
-    this.particles = Particle.create({ amount, location, speed, radius })
+    let amount      = 300
+    let location    = () => ({ x: window.innerWidth / 2, y: window.innerHeight })
+    let speed       = this.setSpeed
+    let radius      = () => window.innerHeight / 2
+    this.intervalId = null
+    this.anchor     = window.document.body
+    this.canvas     = this.createCanvas()
+    this.target     = null
+    this.particles  = Particle.create({ amount, location, speed, radius })
   }
 
-  start() { this.id = setInterval(update, 65) }
+  start() {
+    this.target = this.anchor.appendChild(this.canvas)
+    this.intervalId = setInterval(
+      (function(self) {
+        return function() {
+          self.updateOnInterval()
+        }
+      })(this),
+      65
+    )
+  }
 
   stop() {
-    clearInterval(this.id)
-    clear()
+    clearInterval(this.intervalId)
+    if (this.target) this.target.remove(true)
+  }
+
+  setSpeed() {
+    let value = Math.random() * 0.5
+    return Math.round(Math.random()) === 0 ? value : value * -1
+  }
+
+  createCanvas() {
+    let canvas       = document.createElement('canvas')
+    canvas.id        = 'context-canvas'
+    canvas.className = 'context-canvas'
+    canvas.width     = window.innerWidth
+    canvas.height    = window.innerHeight
+
+    if (canvas.getContext) {
+    }
+
+    return canvas
   }
 
   update(context) {
@@ -30,23 +56,13 @@ class Supergiant {
 
     this.particles = drawParticles(this.particles, context)
   }
-}
 
-export const supergiant = new Supergiant
+  updateOnInterval() {
+    this.canvas.width = window.innerWidth
+    this.canvas.height = window.innerHeight
 
-function clear() {
-  var canvas = document.getElementById("supergiant")
-  var context = canvas.getContext("2d")
+    let context = this.canvas.getContext("2d")
 
-  context.clearRect(0, 0, window.innerWidth, window.innerHeight)
-}
-
-function update() {
-  var canvas = document.getElementById("supergiant")
-  var context = canvas.getContext("2d")
-
-  canvas.width = window.innerWidth
-  canvas.height = window.innerHeight
-
-  supergiant.update(context)
+    this.update(context)
+  }
 }


### PR DESCRIPTION
Apps and Component detail views are supposed to show human-entered friendly
names. This commit fixes that.

Also, the places we use the  background Supergiant have increased, and in
some places, the Supergiant wasn't disappearing on view transition. A more
teardown-friendly version was needed. This commit also refactors the background
Supergiant star, so that the included library itself no longer creates an
instance of the effect. Now, it's up to the React component to create a new
instance of the class and `start()` it.