### PR TITLE
Configurable instance number for releases.

### DIFF
--- a/lib/instances/InstancesSummary.component.js
+++ b/lib/instances/InstancesSummary.component.js
@@ -3,22 +3,30 @@ import { Link } from 'react-router'
 import diff from 'immutablediff'
 import NotFound from '../shared/NotFound.component'
 
-export default class ReleasesDiff extends React.Component {
+export default class InstancesSummary extends React.Component {
   static propTypes = {
     app: React.PropTypes.object.isRequired,
     component: React.PropTypes.object.isRequired,
+    decrease: React.PropTypes.func.isRequired,
     fetchResources: React.PropTypes.func.isRequired,
+    increase: React.PropTypes.func.isRequired,
+    instanceNumber: React.PropTypes.number.isRequired,
     instances: React.PropTypes.object
   }
 
   componentWillMount() { this.props.fetchResources() }
 
   resourcesFound() {
-    const { instances } = this.props
+    const { decrease, increase, instances, instanceNumber } = this.props
 
     return(
       <div className='col-3 lined'>
-        <h3>0 instances</h3>
+        <h3>
+          <a href='#' onClick={ decrease }>-</a>
+          { instanceNumber }
+          <a href='#' onClick={ increase }>+</a>
+           instances
+        </h3>
         <p className='text-note'>
           { instances.count() } deployed
         </p>

--- a/lib/instances/InstancesSummary.container.js
+++ b/lib/instances/InstancesSummary.container.js
@@ -1,13 +1,14 @@
 import { connect } from 'react-redux'
-import { fetch } from './instances.actions'
-import { getComponentInstances } from '../selectors'
+import { increment, decrement, fetch } from './instances.actions'
+import { getComponentInstances, getInstanceCount } from '../selectors'
 import InstancesSummary from './InstancesSummary.component'
 
 function mapStateToProps(state, props) {
   const { app, component } = props
   const instances = getComponentInstances(app, component)(state, props)
+  const instanceNumber = getInstanceCount(state, props)
 
-  return { instances }
+  return { instanceNumber, instances }
 }
 
 function mapDispatchToProps(dispatch, props) {
@@ -17,7 +18,17 @@ function mapDispatchToProps(dispatch, props) {
     dispatch(fetch(app.get('name'), component.get('name'), `target`))
   }
 
-  return { fetchResources }
+  const increase = event => {
+    event.preventDefault()
+    dispatch(increment())
+  }
+
+  const decrease = event => {
+    event.preventDefault()
+    dispatch(decrement())
+  }
+
+  return { increase, decrease, fetchResources }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(InstancesSummary)

--- a/lib/instances/instances.actions.js
+++ b/lib/instances/instances.actions.js
@@ -44,3 +44,8 @@ export const remove = (id, appName, componentName, releaseId) => (
 export const insert = (id, instance, appName, componentName, releaseId) => (
   { type: Insert, id, instance, appName, componentName, releaseId }
 )
+
+export const Increment = "instances:increment"
+export const Decrement = "instances:decrement"
+export const increment = () => ({ type: Increment })
+export const decrement = () => ({ type: Decrement })

--- a/lib/instances/instances.reducers.js
+++ b/lib/instances/instances.reducers.js
@@ -1,7 +1,22 @@
 import { fromJS } from 'immutable'
 import * as InstanceActions from './instances.actions'
 
-export default function instances(state = fromJS({}), action) {
+export function instancesMeta(state = fromJS({}), action) {
+  switch (action.type) {
+    case InstanceActions.Increment:
+      return state.update('counter', counter => {
+        return counter ? counter + 1 : 2
+      })
+    case InstanceActions.Decrement:
+      return state.update('counter', counter => {
+        return counter ? counter - 1 : 0
+      })
+    default:
+      return state
+  }
+}
+
+export function instances(state = fromJS({}), action) {
   const instanceKey = [
     action.appName,
     action.componentName,

--- a/lib/notifications/NotificationBar.container.js
+++ b/lib/notifications/NotificationBar.container.js
@@ -8,7 +8,12 @@ function mapStateToProps(state) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return { close: id => event => dispatch(remove(id)) }
+  const close = id => event => {
+    event.preventDefault()
+    dispatch(remove(id))
+  }
+
+  return { close }
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(NotificationBar)

--- a/lib/reducers.js
+++ b/lib/reducers.js
@@ -7,7 +7,7 @@ import * as NotificationsActions from './notifications/notifications.actions'
 import apps from './apps/apps.reducers'
 import components from './components/components.reducers'
 import containers from './containers/containers.reducers'
-import instances from './instances/instances.reducers'
+import { instancesMeta, instances } from './instances/instances.reducers'
 import entrypoints from './entrypoints/entrypoints.reducers'
 import layouts from './layouts/layouts.reducers'
 import notifications from './notifications/notifications.reducers'
@@ -66,6 +66,7 @@ const manifest = {
   entrypoints,
   form,
   instances,
+  instancesMeta,
   layouts,
   notifications,
   nodes,

--- a/lib/releases/Releases.component.js
+++ b/lib/releases/Releases.component.js
@@ -39,7 +39,7 @@ export default class Releases extends React.Component {
           <div className='context-menu'>
 
             {
-              target.toList().count() > 0 && (
+              target && target.toList().count() > 0 && (
                 <button onClick={ deploy }
                         className='with-glyph glyph-deploy-action-color'>
                   Deploy Changes
@@ -48,7 +48,7 @@ export default class Releases extends React.Component {
             }
 
             {
-              target.toList().count() === 0 && (
+              target && target.toList().count() === 0 && (
                 <button className='with-glyph glyph-plus-action-color'
                         onClick={ create }>
                   Create a Release

--- a/lib/releases/releases.sagas.js
+++ b/lib/releases/releases.sagas.js
@@ -2,6 +2,7 @@ import { fromJS } from 'immutable'
 import { takeEvery } from 'redux-saga'
 import { call, fork, put } from 'redux-saga/effects'
 import { push } from 'react-router-redux'
+import { getInstanceCount } from '../selectors'
 import * as ReleaseEntity from './releases.entity'
 import * as ReleaseActions from './releases.actions'
 import {
@@ -108,13 +109,15 @@ function* getRelease({ id, appName, componentName }) {
   }
 }
 
-export function* createRelease({ params, appName, componentName }) {
+export function* createRelease(getState, { params, appName, componentName }) {
   let release = ReleaseEntity.Release.create(params).toMap()
+  let instance_count = getInstanceCount(getState())
+
   let { response, body } = yield call(
     ReleaseEntity.createRelease,
     appName,
     componentName,
-    release
+    release.merge({ instance_count })
   )
 
   if (response.status === 201) {
@@ -143,7 +146,6 @@ function* deleteRelease({ id, appName, componentName }) {
   if (response.status === 200) {
     yield put(ReleaseActions.remove(id, appName, componentName))
     yield fork(infoMessages, `Deleted release ${id}`)
-    yield put(push(`/apps/${appName}/components/${componentName}/releases`))
   } else {
     if (body.error) {
       yield fork(errorMessages, body.error)
@@ -153,18 +155,35 @@ function* deleteRelease({ id, appName, componentName }) {
   }
 }
 
-function* fetch() { yield takeEvery(ReleaseActions.Fetch, fetchReleases) }
-function* get() { yield takeEvery(ReleaseActions.Get, getRelease) }
-function* current() { yield takeEvery(ReleaseActions.GetCurrent, getCurrent) }
-function* target() { yield takeEvery(ReleaseActions.GetTarget, getTarget) }
-function* create() { yield takeEvery(ReleaseActions.Create, createRelease) }
-function* destroy() { yield takeEvery(ReleaseActions.Destroy, deleteRelease) }
+function* fetch(getState) {
+  yield takeEvery(ReleaseActions.Fetch, fetchReleases)
+}
 
-export function* all() {
-  yield fork(fetch)
-  yield fork(get)
-  yield fork(create)
-  yield fork(current)
-  yield fork(target)
-  yield fork(destroy)
+function* get(getState) {
+  yield takeEvery(ReleaseActions.Get, getRelease)
+}
+
+function* current(getState) {
+  yield takeEvery(ReleaseActions.GetCurrent, getCurrent)
+}
+
+function* target(getState) {
+  yield takeEvery(ReleaseActions.GetTarget, getTarget)
+}
+
+function* create(getState) {
+  yield takeEvery(ReleaseActions.Create, createRelease, getState)
+}
+
+function* destroy(getState) {
+  yield takeEvery(ReleaseActions.Destroy, deleteRelease)
+}
+
+export function* all(getState) {
+  yield fork(fetch, getState)
+  yield fork(get, getState)
+  yield fork(create, getState)
+  yield fork(current, getState)
+  yield fork(target, getState)
+  yield fork(destroy, getState)
 }

--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -17,6 +17,9 @@ export const allInstances = state => state.get('instances')
 export const getContainers = state => allContainers(state).toList()
 export const getVolumes = state => allVolumes(state).toList()
 
+export const getInstanceCount = state =>
+  state.getIn(['instancesMeta', 'counter']) || 1
+
 export const getAppInstances = (app) =>
   (state, props) =>
     allInstances(state, props)

--- a/lib/store/local-storage.js
+++ b/lib/store/local-storage.js
@@ -1,20 +1,7 @@
 import { fromJS } from 'immutable'
 
-const blacklist = [
-  `apps`,
-  `components`,
-  `containers`,
-  `entrypoints`,
-  `form`,
-  `instances`,
-  `layouts`,
-  `nodes`,
-  `releases`,
-  `routing`,
-  `volumes`
-]
-
-const notBlacklisted = (key, val) => !blacklist.includes(val)
+const whitelist = [ `instancesMeta`, `layouts`, `meta` ]
+const whitelisted = (key, val) => whitelist.includes(val)
 
 export function persist(store) {
   return () => {
@@ -22,7 +9,7 @@ export function persist(store) {
       let storage = window.localStorage
       let timestamp = storage.getItem('sg-timestamp')
       let now = Number(new Date)
-      let state = store.getState().filter(notBlacklisted)
+      let state = store.getState().filter(whitelisted)
 
       if (!timestamp) {
         storage.setItem('sg-timestamp', now)

--- a/lib/store/seed.js
+++ b/lib/store/seed.js
@@ -7,15 +7,7 @@ export const seed = parseClouds([
     metadata: {
       tags: [{ name: `name`, value: `Local cloud` }]
     },
-    nodes: [
-      {
-        name: `master`,
-        size: `m4.large`,
-        metadata: {
-          tags: [{ name: `name`, value: `Master node` }]
-        }
-      }
-    ],
+    nodes: [],
     entrypoints: [],
     registries: [],
     apps: []


### PR DESCRIPTION
This is a hack commit introducing a configuration interactor for release
instances.  A few notes about the enclosed:

This is a PR cut in haste.  Right now there's no consideration or input
as to where the interactions should have been placed, so I cooked one up
quick and hope to have someone else actually style the interface
(ideally someone who has a clear idea of the best place to put it).

Also, it is an actual hack.  Right now there is a single entry where
instance count is stored, and it is only persisted in local storage.  So
it works for an individual experience, but needs to be reconfigured for
every component.  There's an opportunity for a quick follow-up pass
here, but it can be released now in order for a styling pass from
another team member.