### PR TITLE
Volume types correspond to AWS options.

### DIFF
--- a/lib/volumes/CreateVolume.component.js
+++ b/lib/volumes/CreateVolume.component.js
@@ -85,26 +85,25 @@ export default class CreateVolume extends React.Component {
               </label>
 
               <div className='button-group'>
-              <label>
-                <input type='radio'
-                       value='ssd'
-                       { ...type }
-                       checked={ type.value === 'ssd' }
-                       defaultChecked='true' />
-                <span className='button'>SSD</span>
-              </label>
                 <label>
                   <input type='radio'
-                         checked={ type.value === 'magnetic' }
                          { ...type }
-                         value='magnetic' />
+                         checked={ type.value === 'gp2' }
+                         value='gp2' />
+                  <span className='button'>SSD</span>
+                </label>
+                <label>
+                  <input type='radio'
+                         { ...type }
+                         checked={ type.value === 'st1' }
+                         value='st1' />
                   <span className='button'>Magnetic</span>
                 </label>
                 <label>
                   <input type='radio'
-                         checked={ type.value === 'iops' }
                          { ...type }
-                         value='iops' />
+                         checked={ type.value === 'io1' }
+                         value='io1' />
                   <span className='button'>IOPS</span>
                 </label>
               </div>

--- a/lib/volumes/CreateVolume.container.js
+++ b/lib/volumes/CreateVolume.container.js
@@ -23,8 +23,9 @@ const validate = values => {
 function mapStateToProps(state, props) {
   let selector = createAppAndComponentSelector()
   let entities = selector(state, props)
+  let initialValues = { type: 'gp2' }
 
-  return { ...entities }
+  return { ...entities, initialValues }
 }
 
 function mapDispatchToProps(dispatch, props) {


### PR DESCRIPTION
Previous volume types were given pretty text which didn't exactly map
one to one with actual AWS options.  This commit implements that
mapping, so that created volumes don't emerge as absolute nonsense when
passed to the API.

An interesting note is that the order of the properties assigned to JSX
/ Redux Form fields is very important.  The first thing passed ought to
be the Redux Form object, and then subsequent properties will override
it.  Otherwise Redux Form will clobber your element properties.