### PR TITLE
Instance counts are keyed to app/component name.

### DIFF
--- a/lib/instances/InstancesSummary.container.js
+++ b/lib/instances/InstancesSummary.container.js
@@ -6,26 +6,26 @@ import InstancesSummary from './InstancesSummary.component'
 function mapStateToProps(state, props) {
   const { app, component } = props
   const instances = getComponentInstances(app, component)(state, props)
-  const instanceNumber = getInstanceCount(state, props)
+  const instanceNumber = getInstanceCount(app, component)(state, props)
 
   return { instanceNumber, instances }
 }
 
 function mapDispatchToProps(dispatch, props) {
+  const { app, component } = props
   const fetchResources = () => {
-    const { app, component } = props
     dispatch(fetch(app.get('name'), component.get('name'), `current`))
     dispatch(fetch(app.get('name'), component.get('name'), `target`))
   }
 
   const increase = event => {
     event.preventDefault()
-    dispatch(increment())
+    dispatch(increment(app.get('name'), component.get('name')))
   }
 
   const decrease = event => {
     event.preventDefault()
-    dispatch(decrement())
+    dispatch(decrement(app.get('name'), component.get('name')))
   }
 
   return { increase, decrease, fetchResources }

--- a/lib/instances/instances.actions.js
+++ b/lib/instances/instances.actions.js
@@ -47,5 +47,11 @@ export const insert = (id, instance, appName, componentName, releaseId) => (
 
 export const Increment = "instances:increment"
 export const Decrement = "instances:decrement"
-export const increment = () => ({ type: Increment })
-export const decrement = () => ({ type: Decrement })
+
+export const increment = (appName, componentName) => (
+  { type: Increment, appName, componentName }
+)
+
+export const decrement = (appName, componentName) => (
+  { type: Decrement, appName, componentName }
+)

--- a/lib/instances/instances.reducers.js
+++ b/lib/instances/instances.reducers.js
@@ -2,13 +2,19 @@ import { fromJS } from 'immutable'
 import * as InstanceActions from './instances.actions'
 
 export function instancesMeta(state = fromJS({}), action) {
+  const keyPath = [
+    `counter`,
+    action.appName,
+    action.componentName
+  ]
+
   switch (action.type) {
     case InstanceActions.Increment:
-      return state.update('counter', counter => {
+      return state.updateIn(keyPath, counter => {
         return counter ? counter + 1 : 2
       })
     case InstanceActions.Decrement:
-      return state.update('counter', counter => {
+      return state.updateIn(keyPath, counter => {
         return counter ? counter - 1 : 0
       })
     default:

--- a/lib/releases/releases.sagas.js
+++ b/lib/releases/releases.sagas.js
@@ -2,7 +2,7 @@ import { fromJS } from 'immutable'
 import { takeEvery } from 'redux-saga'
 import { call, fork, put } from 'redux-saga/effects'
 import { push } from 'react-router-redux'
-import { getInstanceCount } from '../selectors'
+import { selectInstanceCount } from '../selectors'
 import * as ReleaseEntity from './releases.entity'
 import * as ReleaseActions from './releases.actions'
 import {
@@ -111,27 +111,28 @@ function* getRelease({ id, appName, componentName }) {
 
 export function* createRelease(getState, { params, appName, componentName }) {
   let release = ReleaseEntity.Release.create(params).toMap()
-  let instance_count = getInstanceCount(getState())
+  let instance_count = selectInstanceCount(appName, componentName)(getState())
 
-  let { response, body } = yield call(
-    ReleaseEntity.createRelease,
-    appName,
-    componentName,
-    release.merge({ instance_count })
-  )
-
-  if (response.status === 201) {
-    let id = body.timestamp
-
-    yield fork(infoMessages, `Created release '${id}'`)
-    yield fork(refreshReleases, { appName, componentName })
-  } else {
-    if (body.error) {
-      yield fork(errorMessages, body.error)
-    } else {
-      yield fork(errorMessages, body)
-    }
-  }
+  console.log(release.merge({ instance_count }).toJS())
+  // let { response, body } = yield call(
+  //   ReleaseEntity.createRelease,
+  //   appName,
+  //   componentName,
+  //   release.merge({ instance_count })
+  // )
+  //
+  // if (response.status === 201) {
+  //   let id = body.timestamp
+  //
+  //   yield fork(infoMessages, `Created release '${id}'`)
+  //   yield fork(refreshReleases, { appName, componentName })
+  // } else {
+  //   if (body.error) {
+  //     yield fork(errorMessages, body.error)
+  //   } else {
+  //     yield fork(errorMessages, body)
+  //   }
+  // }
 }
 
 function* refreshReleases({ appName, componentName }) {

--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -17,8 +17,13 @@ export const allInstances = state => state.get('instances')
 export const getContainers = state => allContainers(state).toList()
 export const getVolumes = state => allVolumes(state).toList()
 
-export const getInstanceCount = state =>
-  state.getIn(['instancesMeta', 'counter']) || 1
+export const selectInstanceCount = (appName, componentName) =>
+  (state, props) =>
+    state.getIn([`instancesMeta`, `counter`, appName, componentName]) || 1
+
+export const getInstanceCount = (app, component) =>
+  (state, props) =>
+    selectInstanceCount(app.get('name'), component.get('name'))(state, props)
 
 export const getAppInstances = (app) =>
   (state, props) =>


### PR DESCRIPTION
In order to make instance counts more granular, they are now stored
based on a nesting of app and component name.

This storage approach is not my favorite, but it is a little more
expressive overall of how we think of certain tokens of metadata like
this.  I'd like to explore more restructuring of this.

However, having said that, this commit ought to be a sort of moratorium
on code features until there is test coverage and the technical debt
I've been building up can be repaid.