### PR TITLE
Releases should be more resilient.

### DIFF
--- a/lib/releases/ReleaseContainer.component.js
+++ b/lib/releases/ReleaseContainer.component.js
@@ -1,19 +1,22 @@
 import React from 'react'
+import { fromJS } from 'immutable'
+import { kebabCase } from 'lodash'
 import ReleaseVariables from './ReleaseVariables.component'
 import ReleaseMounts from './ReleaseMounts.component'
 import ReleasePorts from './ReleasePorts.component'
 import ReleaseHardware from './ReleaseHardware.component'
-import { kebabCase } from 'lodash'
+
+const idFor = (release, container) =>
+  kebabCase(`${release.get('timestamp')}-${container.get('image')}`)
 
 const ReleaseContainer = ({ container, release }) =>
-  <div id={
-    kebabCase(`${release.get('timestamp')}-${container.get('image')}`)
-  }>
+  <div id={ idFor(release, container) }>
     <h4 className='with-icon icon-city'>{ container.get('image') }</h4>
-    <ReleaseHardware cpu={ container.get('cpu') } ram={ container.get('ram')} />
-    <ReleaseVariables env={ container.get('env') } />
-    <ReleaseMounts mounts={ container.get('mounts') } />
-    <ReleasePorts ports={ container.get('ports') } />
+    <ReleaseHardware cpu={ container.get('cpu') || fromJS({}) }
+                     ram={ container.get('ram') || fromJS({}) } />
+    <ReleaseVariables env={ container.get('env') || fromJS([]) } />
+    <ReleaseMounts mounts={ container.get('mounts') || fromJS([]) } />
+    <ReleasePorts ports={ container.get('ports') || fromJS([]) } />
   </div>
 
 ReleaseContainer.propTypes = {

--- a/lib/releases/ReleaseWelcome.component.js
+++ b/lib/releases/ReleaseWelcome.component.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import ActionButton from '../elements/ActionButton.component'
+import Aside from '../elements/Aside.component'
+import Column from '../elements/Column.component'
+import Row from '../elements/Row.component'
+import TextNote from '../elements/TextNote.component'
+
+const ReleaseWelcome = ({ create }) =>
+  <article className='releases-welcome'>
+    <Row>
+      <Column size={ 3 } />
+
+      <Column size={ 3 }>
+        <h3>Create your first release.</h3>
+      </Column>
+    </Row>
+
+    <Row>
+      <Column size={ 3 } />
+
+      <Column size={ 3 }>
+        <ActionButton isAction={ true } onClick={ create }>
+          Create a Release
+        </ActionButton>
+      </Column>
+
+      <Aside size={ 3 }>
+        <TextNote>
+          When you are ready to deploy your Component, you need to
+          create a new Release.
+        </TextNote>
+        <TextNote>
+          Releases help you keep track of changes to your Component
+          each time you deploy it.
+        </TextNote>
+      </Aside>
+    </Row>
+  </article>
+
+ReleaseWelcome.propTypes = { create: React.PropTypes.func.isRequired }
+
+export default ReleaseWelcome

--- a/lib/releases/Releases.component.js
+++ b/lib/releases/Releases.component.js
@@ -1,16 +1,12 @@
 import React from 'react'
-import ActionButton from '../elements/ActionButton.component'
-import Aside from '../elements/Aside.component'
-import Column from '../elements/Column.component'
 import ContextHeader from '../elements/ContextHeader.component'
 import ContextMenu from '../elements/ContextMenu.component'
 import ContextTitle from '../elements/ContextTitle.component'
 import DeployButton from '../elements/DeployButton.component'
 import DestroyButton from '../elements/DestroyButton.component'
 import PlusButton from '../elements/PlusButton.component'
-import Row from '../elements/Row.component'
-import TextNote from '../elements/TextNote.component'
 import Release from './Release.component'
+import ReleaseWelcome from './ReleaseWelcome.component'
 import FadeChange from '../shared/FadeChange.animation'
 import NotFound from '../shared/NotFound.component'
 
@@ -75,40 +71,7 @@ export default class Releases extends React.Component {
           </ContextMenu>
         </ContextHeader>
 
-        {
-          releases.count() === 0 && (
-            <article className='releases-welcome'>
-              <Row>
-                <Column size={ 3 } />
-
-                <Column size={ 3 }>
-                  <h3>Create your first release.</h3>
-                </Column>
-              </Row>
-
-              <Row>
-                <Column size={ 3 } />
-
-                <Column size={ 3 }>
-                  <ActionButton isAction={ true } onClick={ create }>
-                    Create a Release
-                  </ActionButton>
-                </Column>
-
-                <Aside size={ 3 }>
-                  <TextNote>
-                    When you are ready to deploy your Component, you need to
-                    create a new Release.
-                  </TextNote>
-                  <TextNote>
-                    Releases help you keep track of changes to your Component
-                    each time you deploy it.
-                  </TextNote>
-                </Aside>
-              </Row>
-            </article>
-          )
-        }
+        { releases.count() === 0 && <ReleaseWelcome create={ create } /> }
 
         <div className='accordion-table'>
           {

--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -1,8 +1,10 @@
 import { fromJS } from 'immutable'
 import { createSelector } from 'reselect'
 
+export const allApps = state => state.getIn(['apps', 'contents'])
+export const getApps = state => allApps(state).toList()
+
 export const getActiveCloud = state => state.get('clouds').toList().first()
-export const getApps = state => state.get('apps').toList()
 export const getComponents = state => state.get('components')
 export const getNodes = state => state.get('nodes').toList()
 export const isFaded = state => state.getIn(['layouts', 'faded'])
@@ -48,9 +50,12 @@ export const getReleases = state =>
     .toList()
 
 export const getApp = (state, props) =>
-  state.get('apps').get(
-    props.appName ||
-    props.params && props.params.appName
+  state.getIn(
+    [
+      'apps',
+      'contents',
+      (props.appName || props.params && props.params.appName)
+    ]
   )
 
 export const getComponent = (state, props) => {


### PR DESCRIPTION
Some release fields don't really turn out to be that necessary to
display 100% of the time.  This commit ensures that they function even
in cases where there is nothing to display.

Also, there was an issue where (now legacy) app selectors weren't
functioning with the new model of the app reducer.  That problem should
be resolved now, until those selectors are deprecated and removed.

Finally, in the element decoupling process the Release welcome message
wasn't moved into its own component.  Now it has been.