### PR TITLE
Client for components, releases and deploys

### DIFF
--- a/lib/resources/components-spec.js
+++ b/lib/resources/components-spec.js
@@ -1,0 +1,38 @@
+import Component from './entities/component'
+import Components from './components'
+
+describe("Components client", () => {
+  const client = new Components({ client: mockClient(Component) })
+
+  describe("get", () => {
+    it("returns a component", () => {
+      expect(client.get('ci')).to.eventually.be.an.instanceof(Component)
+    })
+  })
+
+  describe("fetch", () => {
+    it("returns a list", () => {
+      expect(client.fetch()).to.eventually.be.an.instanceof(Array)
+    })
+  })
+
+  describe("create", () => {
+    it("returns a component", () => {
+      const promise = client.create({ name: 'key' })
+      expect(promise).to.eventually.be.an.instanceof(Component)
+    })
+  })
+
+  describe("delete", () => {
+    it("returns an empty object", () => {
+      expect(client.delete('key')).to.eventually.be.an.instanceof(Object)
+    })
+  })
+
+  describe("update", () => {
+    it("returns a component", () => {
+      let component = new Component({ name: "CI" })
+      expect(client.update(component)).to.eventually.be.an.instanceof(Component)
+    })
+  })
+})

--- a/lib/resources/components.js
+++ b/lib/resources/components.js
@@ -1,0 +1,23 @@
+import ResourceClient from './resource-client'
+import Component from './entities/component'
+
+const composeApi = ({ client, scope }) => {
+  const api = new ResourceClient({ client })
+
+  api.route = `${scope}/components`
+  api.resource = Component
+
+  return api
+}
+
+export default class Components {
+  constructor({ client, scope }) {
+    const api = composeApi({ client, scope })
+
+    for (let property of Reflect.ownKeys(api)) {
+      let method = Reflect.get(api, property)
+
+      Reflect.set(this, property, method)
+    }
+  }
+}

--- a/lib/resources/deploys-spec.js
+++ b/lib/resources/deploys-spec.js
@@ -1,0 +1,13 @@
+import Deploy from './entities/deploy'
+import Deploys from './deploys'
+
+describe("Deploys client", () => {
+  const client = new Deploys({ client: mockClient(Deploy) })
+
+  describe("create", () => {
+    it("returns a deploy", () => {
+      const promise = client.create({ name: 'key' })
+      expect(promise).to.eventually.be.an.instanceof(Deploy)
+    })
+  })
+})

--- a/lib/resources/deploys.js
+++ b/lib/resources/deploys.js
@@ -1,0 +1,20 @@
+import ResourceClient from './resource-client'
+import Deploy from './entities/deploy'
+
+const composeApi = ({ client, scope }) => {
+  const api = new ResourceClient({ client })
+
+  api.route = `${scope}/deploy`
+  api.resource = Deploy
+
+  return api
+}
+
+export default class Deploys {
+  constructor({ client, scope }) {
+    const api = composeApi({ client, scope })
+
+    this.create = api.create
+    this.route = api.route
+  }
+}

--- a/lib/resources/entities/app-spec.js
+++ b/lib/resources/entities/app-spec.js
@@ -18,7 +18,10 @@ describe("App", () => {
       expect(app.tags.get('name')).to.equal(name)
     })
 
-    it("it creates an id tag", () => expect(app.tags.get('id')).to.be.ok)
+    it("creates an id tag", () => expect(app.tags.get('id')).to.be.ok)
+    it("creates a uri", () => {
+      expect(app.uri).to.equal(`/api/v0/apps/${kebabCase(name)}`)
+    })
   })
 
   describe("id", () => {
@@ -32,6 +35,16 @@ describe("App", () => {
     const app = new App({ name })
 
     it("returns the kebab name", () => expect(app.key()).to.equal(app.name))
+  })
+
+  describe("components", () => {
+    const name = "App With Components"
+    const app = new App({ name })
+    const route = `/api/v0/apps/${app.name}/components`
+
+    it("is a client with an app-specific uri", () => {
+      expect(app.components.route).to.equal(route)
+    })
   })
 
   describe("displayName", () => {

--- a/lib/resources/entities/app.js
+++ b/lib/resources/entities/app.js
@@ -1,6 +1,7 @@
 import uuid from 'uuid'
 import { fromJS, Record } from 'immutable'
 import { kebabCase } from 'lodash'
+import Components from '../components'
 
 const appSchema = { name: ``, tags: {}, created: ``, updated: `` }
 
@@ -14,6 +15,9 @@ export default class App extends Record(appSchema) {
         .update('id', id => id || uuid.v4())
         .update('name', currentName => currentName || name)
     })
+
+    this.uri = `/api/v0/apps/${this.name}`
+    this.components = new Components({ scope: this.uri })
   }
 
   displayName() { return this.tags.get('name') }

--- a/lib/resources/entities/component-spec.js
+++ b/lib/resources/entities/component-spec.js
@@ -1,0 +1,158 @@
+import Immutable from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Component from './component'
+import Releases from '../releases'
+import Deploys from '../deploys'
+
+describe("Component", () => {
+  describe("initializing", () => {
+    const name = `Component Name`
+    const color = `#828`
+    const appName = `A Superb App Name`
+    const tags = { }
+    const component = new Component({ appName, color, name, color, tags })
+
+    it("creates a slug name", () => {
+      expect(component.name).to.equal(kebabCase(name))
+    })
+
+    it("responds to tags", () => {
+      expect(component.tags).to.be.an.instanceof(Immutable.Map)
+    })
+
+    it("stores the original name in a tag", () => {
+      expect(component.tags.get('name')).to.equal(name)
+    })
+
+    it("stores the color in a tag", () => {
+      expect(component.tags.get('color')).to.equal(color)
+    })
+
+    it("stores an app name in a tag", () => {
+      expect(component.tags.get('appName')).to.equal(appName)
+    })
+
+    it("stores an app key in a tag", () => {
+      expect(component.tags.get('appKey')).to.equal(kebabCase(appName))
+    })
+
+    it("creates a uri", () => {
+      expect(component.uri).to.equal(
+        `/api/v0/apps/${component.app.key()}/components/${component.name}`
+      )
+    })
+
+    it("it creates an id tag", () => expect(component.tags.get('id')).to.be.ok)
+  })
+
+  describe("app", () => {
+    const name = `Component Name`
+    const color = `#828`
+    const appName = `A Superb App Name`
+    const component = new Component({ appName, color, name, color })
+
+    it("is a convenience getter for the app", () => {
+      expect(component.app).to.be.instanceof(App)
+    })
+  })
+
+  describe("id", () => {
+    const component = new Component({ })
+
+    it("returns the id tag", () => {
+      expect(component.id()).to.equal(component.tags.get('id'))
+    })
+  })
+
+  describe("key", () => {
+    const name = "Mega Component Prime"
+    const component = new Component({ name })
+
+    it("returns the kebab name", () => {
+      expect(component.key()).to.equal(component.name)
+    })
+  })
+
+  describe("displayName", () => {
+    const name = "A Fancy Component Name"
+    const component = new Component({ name })
+
+    it("returns the tag name", () => {
+      expect(component.displayName()).to.equal(name)
+    })
+  })
+
+  describe("toPayload", () => {
+    const name = "Super Fancy New Component"
+    const component = new Component({ name })
+    const payload = component.toPayload()
+
+    it("marshals the right tags for the API", () => {
+      for (let tag of [`id`, `name`]) {
+        let tagValue = Reflect.get(payload.tags, tag)
+        expect(tagValue).to.be.ok
+      }
+    })
+
+    it("marshals a kebab-case name", () => {
+      expect(payload.name).to.equal(kebabCase(name))
+    })
+  })
+
+  describe("deploys", () => {
+    const name = `Component To Deploy`
+    const color = `#828`
+    const appName = `App With Components`
+    const tags = { }
+    const component = new Component({ appName, color, name, color, tags })
+    const route = `${component.uri}/deploy`
+
+    it("is a client with a component-specific deploy uri", () => {
+      expect(component.deploys.route).to.equal(route)
+    })
+
+    it("is a deploys client", () => {
+      expect(component.deploys).to.be.instanceof(Deploys)
+    })
+  })
+
+  describe("releases", () => {
+    const name = `Component With Releases`
+    const color = `#828`
+    const appName = `App With Components`
+    const tags = { }
+    const component = new Component({ appName, color, name, color, tags })
+    const route = `${component.uri}/releases`
+
+    it("is a client with a component-specific releases uri", () => {
+      expect(component.releases.route).to.equal(route)
+    })
+
+    it("is a releases client", () => {
+      expect(component.releases).to.be.instanceof(Releases)
+    })
+  })
+
+  describe("marshaling from an API", () => {
+    const payload = {
+      name: "ci",
+      created: (new Date).toString(),
+      updated: null,
+      tags: {
+        name: "Ultra Name"
+      }
+    }
+
+    const component = new Component(payload)
+
+    it("exposes a name", () => expect(component.name).to.equal(payload.name))
+
+    it("has a displayName", () => {
+      expect(component.displayName()).to.equal(payload.tags.name)
+    })
+
+    it("creates an ID", () => expect(component.tags.get('id')).to.be.ok )
+
+  })
+})

--- a/lib/resources/entities/component.js
+++ b/lib/resources/entities/component.js
@@ -1,0 +1,54 @@
+import uuid from 'uuid'
+import { fromJS, Record } from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Deploys from '../deploys'
+import Releases from '../releases'
+
+const componentSchema = {
+  appName: ``,
+  color: ``,
+  created: ``,
+  name: ``,
+  tags: {},
+  updated: ``
+}
+
+export default class Component extends Record(componentSchema) {
+  constructor(params) {
+    const {
+      appName,
+      color,
+      created,
+      name,
+      tags = {},
+      updated
+    } = params
+
+    super({
+      name: kebabCase(name),
+      created,
+      updated,
+      tags: fromJS(tags)
+        .update('appKey', cached => cached || kebabCase(appName))
+        .update('appName', cached => cached || appName)
+        .update('color', cached => cached || color)
+        .update('id', cached => cached || uuid.v4())
+        .update('name', cached => cached || name)
+    })
+
+    this.app = new App({ name: this.tags.get('appName') })
+    this.uri = `/api/v0/apps/${this.app.key()}/components/${this.name}`
+    this.releases = new Releases({ scope: this.uri })
+    this.deploys = new Deploys({ scope: this.uri })
+  }
+
+  displayName() { return this.tags.get('name') }
+  id() { return this.tags.get('id') }
+  key() { return this.name }
+
+  toPayload() {
+    const { name, tags } = this
+    return { name, tags: tags.toJS() }
+  }
+}

--- a/lib/resources/entities/deploy-spec.js
+++ b/lib/resources/entities/deploy-spec.js
@@ -1,0 +1,31 @@
+import Immutable from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Component from './component'
+import Deploy from './deploy'
+
+describe("Deploy", () => {
+  describe("initializing", () => {
+    const componentName = `Component Name`
+    const appName = `App Name`
+    const deploy = new Deploy({ appName, componentName })
+
+    it("creates an app entity reference", () => {
+      expect(deploy.app).to.be.instanceof(App)
+    })
+
+    it("creates a component entity reference", () => {
+      expect(deploy.component).to.be.instanceof(Component)
+    })
+
+    it("creates a uri", () => {
+      const app = deploy.app
+      const component = deploy.component
+
+      expect(deploy.uri).to.equal(
+        `/api/v0/apps/${app.key()}/components/${component.key()}/deploy`
+      )
+    })
+
+  })
+})

--- a/lib/resources/entities/deploy.js
+++ b/lib/resources/entities/deploy.js
@@ -1,0 +1,21 @@
+import uuid from 'uuid'
+import { fromJS, Record } from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Component from './component'
+
+const deploySchema = { }
+
+export default class Deploy extends Record(deploySchema) {
+  constructor(params) {
+    const { appName, componentName } = params
+
+    super(params)
+
+    this.app = new App({ name: appName })
+    this.component = new Component({ name: appName, appName })
+    this.uri = `${this.component.uri}/deploy`
+  }
+
+  toPayload() { return { } }
+}

--- a/lib/resources/entities/release-spec.js
+++ b/lib/resources/entities/release-spec.js
@@ -1,0 +1,137 @@
+import Immutable from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Component from './component'
+import Instance from './instance'
+import Release from './release'
+
+describe("Release", () => {
+  describe("initializing", () => {
+    const componentName = `Component Name`
+    const appName = `App Name`
+    const instance_number = 1
+    const termination_grace_period = 10
+    const timestamp = 105125018
+    const tags = { }
+
+    const release = new Release({
+      appName,
+      componentName,
+      instance_number,
+      termination_grace_period,
+      tags,
+      timestamp
+    })
+
+    it("responds to instance_number", () => {
+      expect(release.instance_number).to.be.ok
+    })
+
+    it("responds to termination_grace_period", () => {
+      expect(release.termination_grace_period).to.be.ok
+    })
+
+    it("responds to volumes", () => {
+      expect(release.volumes).to.be.an.instanceof(Immutable.List)
+    })
+
+    it("responds to containers", () => {
+      expect(release.containers).to.be.an.instanceof(Immutable.List)
+    })
+
+    it("responds to tags", () => {
+      expect(release.tags).to.be.an.instanceof(Immutable.Map)
+    })
+
+    it("creates an app entity reference", () => {
+      expect(release.app).to.be.instanceof(App)
+    })
+
+    it("creates a component entity reference", () => {
+      expect(release.component).to.be.instanceof(Component)
+    })
+
+    it("creates a uri", () => {
+      const app = release.app
+      const component = release.component
+
+      expect(release.uri).to.equal(
+        `${component.uri}/releases/${release.timestamp}`
+      )
+    })
+
+    it("stores the component name in a tag", () => {
+      expect(release.tags.get('componentName')).to.equal(componentName)
+    })
+
+    it("stores the component key in a tag", () => {
+      expect(release.tags.get('componentKey')).to.equal(
+        kebabCase(componentName)
+      )
+    })
+
+    it("stores an app name in a tag", () => {
+      expect(release.tags.get('appName')).to.equal(appName)
+    })
+
+    it("stores an app key in a tag", () => {
+      expect(release.tags.get('appKey')).to.equal(kebabCase(appName))
+    })
+
+    it("it creates an id tag", () => expect(release.tags.get('id')).to.be.ok)
+  })
+
+  describe("id", () => {
+    const release = new Release({ })
+
+    it("returns the id tag", () => {
+      expect(release.id()).to.equal(release.tags.get('id'))
+    })
+  })
+
+  describe("key", () => {
+    const name = "Mega Release Prime"
+    const timestamp = 105125018
+    const release = new Release({ name, timestamp })
+
+    it("returns the timestamp", () => {
+      expect(release.key()).to.equal(release.timestamp)
+    })
+  })
+
+  describe("toPayload", () => {
+    const appName = "Super Fancy New Release"
+    const componentName = "Super Fancy New Release"
+    const release = new Release({ appName, componentName })
+    const payload = release.toPayload()
+
+    it("marshals the right tags for the API", () => {
+      let tags = [
+        `appKey`,
+        `appName`,
+        `componentKey`,
+        `componentName`,
+        `id`
+      ]
+
+      for (let tag of tags) {
+        let tagValue = Reflect.get(payload.tags, tag)
+        expect(tagValue).to.be.ok
+      }
+    })
+  })
+
+  describe("marshaling from an API", () => {
+    const payload = {
+      name: "ci",
+      created: (new Date).toString(),
+      timestamp: 1058105825,
+      updated: null,
+      tags: {}
+    }
+
+    const release = new Release(payload)
+
+    it("creates an ID", () => expect(release.tags.get('id')).to.be.ok )
+  })
+})

--- a/lib/resources/entities/release.js
+++ b/lib/resources/entities/release.js
@@ -1,0 +1,61 @@
+import uuid from 'uuid'
+import { fromJS, Record } from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Component from './component'
+
+const releaseSchema = {
+  containers: [],
+  created: ``,
+  instance_number: ``,
+  tags: {},
+  termination_grace_period: ``,
+  timestamp: ``,
+  updated: ``,
+  volumes: []
+}
+
+export default class Release extends Record(releaseSchema) {
+  constructor(params) {
+    const {
+      appName,
+      componentName,
+      containers = [],
+      created,
+      instance_number = 1,
+      tags = {},
+      termination_grace_period = 10,
+      timestamp,
+      updated,
+      volumes = []
+    } = params
+
+    super({
+      created,
+      instance_number,
+      updated,
+      termination_grace_period,
+      timestamp,
+      containers: fromJS(containers),
+      volumes: fromJS(volumes),
+      tags: fromJS(tags)
+        .update('appKey', cached => cached || kebabCase(appName))
+        .update('appName', cached => cached || appName)
+        .update('componentKey', cached => cached || kebabCase(componentName))
+        .update('componentName', cached => cached || componentName)
+        .update('id', cached => cached || uuid.v4())
+    })
+
+    this.app = new App({ name: appName })
+    this.component = new Component({ name: appName, appName })
+    this.uri = `${this.component.uri}/releases/${this.timestamp}`
+  }
+
+  id() { return this.tags.get('id') }
+  key() { return this.timestamp }
+
+  toPayload() {
+    const { name, tags } = this
+    return { name, tags: tags.toJS() }
+  }
+}

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -1,5 +1,7 @@
 export Apps from './apps'
+export Components from './components'
 export Nodes from './nodes'
 export Entrypoints from './entrypoints'
+export Releases from './releases'
 export Repos from './repos'
 export Tasks from './tasks'

--- a/lib/resources/releases-spec.js
+++ b/lib/resources/releases-spec.js
@@ -1,0 +1,38 @@
+import Release from './entities/release'
+import Releases from './releases'
+
+describe("Releases client", () => {
+  const client = new Releases({ client: mockClient(Release) })
+
+  describe("get", () => {
+    it("returns a release", () => {
+      expect(client.get(120582150)).to.eventually.be.an.instanceof(Release)
+    })
+  })
+
+  describe("fetch", () => {
+    it("returns a list", () => {
+      expect(client.fetch()).to.eventually.be.an.instanceof(Array)
+    })
+  })
+
+  describe("create", () => {
+    it("returns a release", () => {
+      const promise = client.create({ name: 'key' })
+      expect(promise).to.eventually.be.an.instanceof(Release)
+    })
+  })
+
+  describe("delete", () => {
+    it("returns an empty object", () => {
+      expect(client.delete('key')).to.eventually.be.an.instanceof(Object)
+    })
+  })
+
+  describe("update", () => {
+    it("returns a release", () => {
+      let release = new Release({ name: "CI" })
+      expect(client.update(release)).to.eventually.be.an.instanceof(Release)
+    })
+  })
+})

--- a/lib/resources/releases.js
+++ b/lib/resources/releases.js
@@ -1,0 +1,23 @@
+import ResourceClient from './resource-client'
+import Release from './entities/release'
+
+const composeApi = ({ client, scope }) => {
+  const api = new ResourceClient({ client })
+
+  api.route = `${scope}/releases`
+  api.resource = Release
+
+  return api
+}
+
+export default class Releases {
+  constructor({ client, scope }) {
+    const api = composeApi({ client, scope })
+
+    for (let property of Reflect.ownKeys(api)) {
+      let method = Reflect.get(api, property)
+
+      Reflect.set(this, property, method)
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces components, releases and deploys to the client
continuity.  At this point, only these remain:

* Instances, Start Instance, and Stop Instance
* Ephemeral entities (containers, volumes, variables, ports, mounts)