### PR TITLE
Display only current instances in component page.

### DIFF
--- a/lib/elements/CpuMeter.component.js
+++ b/lib/elements/CpuMeter.component.js
@@ -1,24 +1,35 @@
 import React from 'react'
 import { floatFloorToPlaces } from '../shared/normalizers'
 
+const getWidth = (usage, limit) =>
+  Math.round((usage / Math.max(limit || 1)) * 100)
+
 const CpuMeter = ({ usage, limit }) =>
-  <span>
-    <div className='status-meter with-label-right'
-         title={ `${ usage / 1000 } / ${ limit / 1000 } CPUs used`}>
-      {
-        (usage && limit) && (
-          <div className='status-metric'
-               title={ `${ usage / 1000 } CPU` }
-               style={
-                 { width: `${Math.round((usage / limit) * 100)}%` }
-               } />
-        )
-      }
-    </div>
-    <div className='label-right'>CPU</div>
-    <p className='text-note row'>
-      { floatFloorToPlaces(usage / 1000) } used / { floatFloorToPlaces(limit / 1000) } CPU limit
-    </p>
-  </span>
+  limit !== 0
+    ? (
+      <span>
+        <div className='status-meter with-label-right'
+             title={ `${ usage / 1000 } / ${ limit / 1000 } CPUs used`}>
+          {
+            (usage && limit) && (
+              <div className='status-metric'
+                   title={ `${ usage / 1000 } CPU` }
+                   style={
+                     { width: `${getWidth(usage, limit)}%` }
+                   } />
+            )
+          }
+        </div>
+        <div className='label-right'>CPU</div>
+        <p className='text-note row'>
+          {
+            floatFloorToPlaces(usage / 1000)
+          } used / {
+            floatFloorToPlaces(limit / 1000)
+          } CPU limit
+        </p>
+      </span>
+    )
+  : <div />
 
 export default CpuMeter

--- a/lib/elements/RamMeter.component.js
+++ b/lib/elements/RamMeter.component.js
@@ -1,23 +1,31 @@
 import React from 'react'
 import { floatToDataUnits } from '../shared/normalizers'
 
+const getWidth = (usage, limit) =>
+  Math.round((usage / Math.max(limit || 1)) * 100)
+
+const getTitle = (usage, limit ) =>
+  `${ floatToDataUnits(usage) } / ${ floatToDataUnits(limit) } RAM used`
+
 const RamMeter = ({ usage, limit }) =>
-  <span>
-    <div className='status-meter with-label-right'
-         title={ `${ floatToDataUnits(usage) } / ${ floatToDataUnits(limit) } RAM used` } >
-      {
-        (usage && limit) && (
-          <div className='status-metric'
-               style={
-                 { width: `${Math.round((usage / limit) * 100)}%` }
-               } />
-        )
-      }
-    </div>
-    <div className='label-right'>RAM</div>
-    <p className='text-note row'>
-      { floatToDataUnits(usage || 0) } used / { floatToDataUnits(limit) } RAM limit
-    </p>
-  </span>
+  limit !== 0
+    ? (
+        <span>
+          <div className='status-meter with-label-right'
+               title={ getTitle(usage, limit) } >
+            {
+              (usage && limit) && (
+                <div className='status-metric'
+                     style={ { width: `${getWidth(usage, limit)}%` } } />
+              )
+            }
+          </div>
+          <div className='label-right'>RAM</div>
+          <p className='text-note row'>
+            { floatToDataUnits(usage || 0) } used / { floatToDataUnits(limit) } RAM limit
+          </p>
+        </span>
+      )
+    : <div />
 
 export default RamMeter

--- a/lib/instances/Instances.container.js
+++ b/lib/instances/Instances.container.js
@@ -1,11 +1,11 @@
 import { connect } from 'react-redux'
-import { getComponentInstances } from '../selectors'
+import { getCurrentInstances } from './instances.selectors'
 import { fetch } from './instances.actions'
 import Instances from './Instances.component'
 
 function mapStateToProps(state, props) {
   const { app, component } = props
-  const instances = getComponentInstances(app, component)(state, props)
+  const instances = getCurrentInstances(app, component)(state, props)
 
   return { instances }
 }
@@ -14,7 +14,6 @@ function mapDispatchToProps(dispatch, props) {
   const { app, component } = props
   const fetchResources = () => {
     dispatch(fetch(app.get('name'), component.get('name'), `current`))
-    dispatch(fetch(app.get('name'), component.get('name'), `target`))
   }
 
   return { fetchResources }

--- a/lib/instances/instances.selectors.js
+++ b/lib/instances/instances.selectors.js
@@ -1,0 +1,13 @@
+import { fromJS } from 'immutable'
+import { createSelector } from 'reselect'
+
+export const allInstances = state => state.get('instances')
+
+export const getCurrentInstances = (app, component) =>
+  (state, props) =>
+    allInstances(state, props)
+      .filter((instance, key) => (
+        key.includes(app.name) && key.includes(component.get('name'))
+      ))
+      .filter((instance, key) => key.includes(`current`))
+      .toList()


### PR DESCRIPTION
We only really care about current instances, since target instances are
a future entity set which are being stood up.  The Instances list should
only display current instances.