### PR TITLE
Component detail page displays external addresses.

### DIFF
--- a/lib/components/ComponentDetail.component.js
+++ b/lib/components/ComponentDetail.component.js
@@ -7,6 +7,7 @@ import ContextOverview from '../elements/ContextOverview.component'
 import ContextTitle from '../elements/ContextTitle.component'
 import DestroyButton from '../elements/DestroyButton.component'
 import InlineTextNote from '../elements/InlineTextNote.component'
+
 import ComponentDetailResources from './ComponentDetailResources.component'
 import ReleasesDiff from '../releases/ReleasesDiff.container'
 import ReleaseSummary from '../releases/ReleaseSummary.container'
@@ -56,6 +57,29 @@ export default class ComponentDetail extends React.Component {
   componentDidMount() { this.backgroundCanvas.start() }
   componentWillUnmount() { this.backgroundCanvas.stop() }
 
+  externalAddresses() {
+    const externals = this.props.component.getIn(['addresses', 'external'])
+
+    if (externals && externals.count() > 0) {
+      return(
+        <ContextOverview>
+          <Column size={ 12 }>
+            <h4>External addresses:</h4>
+            {
+              externals.map((external, index) => (
+                <p>
+                  <a href={ external.get('address') } target='_blank'>
+                    { external.get('address') }
+                  </a>
+                </p>
+              ))
+            }
+          </Column>
+        </ContextOverview>
+      )
+    }
+  }
+
   resourcesFound() {
     const {
       app,
@@ -95,6 +119,8 @@ export default class ComponentDetail extends React.Component {
           <Column size={ 1 } />
           <InstancesStatus app={ app } component={ component } />
         </ContextOverview>
+
+        { this.externalAddresses() }
 
         <ComponentDetailResources>
           <Containers component={ component } app={ app } />

--- a/lib/components/ComponentDetail.container.js
+++ b/lib/components/ComponentDetail.container.js
@@ -21,8 +21,9 @@ function mapDispatchToProps(dispatch, props) {
   }
 
   const goToReleases = event => {
-    const appRoot = `/apps/${app.name}`
-    const componentRoot = `/components/${component.get('name')}`
+    const appRoot = `/apps/${props.params.appName}`
+    const componentRoot = `/components/${props.params.componentName}`
+
     dispatch(push(`${appRoot}${componentRoot}/releases`))
   }
 

--- a/lib/components/components.entity.js
+++ b/lib/components/components.entity.js
@@ -18,10 +18,10 @@ export const saveComponent = (appName, component) =>
   new ResourceClient(componentRoute(appName)).create(component.toJS())
 
 export class Component {
-  static from({ tags, name }, appName) {
+  static from({ tags, name, addresses }, appName) {
     let key = [appName, name].join('-')
 
-    return new Component({ tags, name: key })
+    return new Component({ addresses, tags, name: key })
   }
 
   static create(params, appName) {
@@ -32,8 +32,9 @@ export class Component {
     return new Component({ name: key, tags })
   }
 
-  constructor({ name, tags }, appName) {
+  constructor({ name, addresses, tags }, appName) {
     this.name = name
+    this.addresses = fromJS(addresses)
     this.tags = fromJS(tags)
   }
 
@@ -64,6 +65,7 @@ export class Component {
       name: kebabCase(this.tags.get('name')),
       tags: this.tags,
       id: this.name,
+      addresses: this.addresses,
       containers: this.containers(),
       volumes: this.volumes(),
       instance_number: this.tags.get('instance_number'),


### PR DESCRIPTION
In order to provide a convenient way for users to access component
instances, we want to expose addresses in an easy to find way: the
component detail page.