### PR TITLE
Introduce instance client support.

### DIFF
--- a/lib/resources/entities/instance-spec.js
+++ b/lib/resources/entities/instance-spec.js
@@ -1,0 +1,111 @@
+import Immutable from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Component from './component'
+import Release from './release'
+import Instance from './instance'
+import Meter from './meter'
+
+describe("Instance", () => {
+  describe("initializing", () => {
+    const componentName = `Component Name`
+    const appName = `App Name`
+    const timestamp = 105125018
+
+    const instance = new Instance({
+      appName,
+      componentName,
+      timestamp
+    })
+
+    it("responds to cpu", () => {
+      expect(instance.cpu).to.be.an.instanceof(Meter)
+    })
+
+    it("responds to ram", () => {
+      expect(instance.ram).to.be.an.instanceof(Meter)
+    })
+
+    it("creates an app entity reference", () => {
+      expect(instance.app).to.be.instanceof(App)
+    })
+
+    it("creates a component entity reference", () => {
+      expect(instance.component).to.be.instanceof(Component)
+    })
+
+    it("creates a release entity reference", () => {
+      expect(instance.release).to.be.instanceof(Release)
+    })
+
+    it("creates a uri", () => {
+      const release = instance.release
+
+      expect(instance.uri).to.equal(`${release.uri}/instances/${instance._id}`)
+    })
+  })
+
+  describe("id", () => {
+    const id = 0
+    const instance = new Instance({ id })
+
+    it("returns the id", () => expect(instance.id()).to.equal(id))
+  })
+
+  describe("bundled clients", () => {
+    const appName = 'App Name'
+    const componentName = 'Component Name'
+    const timestamp = 105125018
+    const id = 0
+    const instance = new Instance({ appName, componentName, timestamp, id })
+
+    describe("log", () => {
+      it("is a client with an instance-specific uri", () => {
+        expect(instance.log.route).to.equal(`${instance.uri}/log`)
+      })
+    })
+
+    describe("start", () => {
+      it("is a client with an instance-specific uri", () => {
+        expect(instance.start.route).to.equal(`${instance.uri}/start`)
+      })
+    })
+
+    describe("stop", () => {
+      it("is a client with an instance-specific uri", () => {
+        expect(instance.stop.route).to.equal(`${instance.uri}/stop`)
+      })
+    })
+
+  })
+
+  describe("key", () => {
+    const id = 0
+    const instance = new Instance({ id })
+
+    it("returns the id", () => expect(instance.key()).to.equal(id))
+  })
+
+  describe("marshaling from an API", () => {
+    const meter = { usage: 0, limit: 0 }
+    const payload = {
+      id: 0,
+      base_name: 'ci-12345',
+      name: "ci",
+      cpu: meter,
+      ram: meter
+    }
+
+    const instance = new Instance(payload)
+
+    it("marshals cpu meters", () => {
+      expect(instance.cpu.usage).to.equal(meter.usage)
+      expect(instance.cpu.limit).to.equal(meter.limit)
+    })
+
+    it("marshals ram meters", () => {
+      expect(instance.ram.usage).to.equal(meter.usage)
+      expect(instance.ram.limit).to.equal(meter.limit)
+    })
+  })
+})

--- a/lib/resources/entities/instance.js
+++ b/lib/resources/entities/instance.js
@@ -1,0 +1,52 @@
+import uuid from 'uuid'
+import { fromJS, Record } from 'immutable'
+import { kebabCase } from 'lodash'
+import App from './app'
+import Component from './component'
+import Release from './release'
+import Meter from './meter'
+import Log from '../log'
+import Start from '../start'
+import Stop from '../stop'
+
+const instanceSchema = {
+  id: ``,
+  base_name: ``,
+  name: ``,
+  status: `STOPPED`,
+  cpu: new Meter({}),
+  ram: new Meter({})
+}
+
+export default class Instance extends Record(instanceSchema) {
+  constructor(params) {
+    const { id, base_name, name, status, cpu = {}, ram = {} } = params
+    const { appName, componentName, timestamp } = params
+
+    super({
+      id,
+      base_name,
+      name,
+      status,
+      cpu: new Meter(cpu),
+      ram: new Meter(ram)
+    })
+
+    this._id = id
+    this.app = new App({ name: appName })
+    this.component = new Component({ name: componentName, appName })
+    this.release = new Release({ componentName, appName, timestamp })
+    this.uri = `${this.release.uri}/instances/${id}`
+    this.log = new Log({ scope: this.uri })
+    this.start = new Start({ scope: this.uri })
+    this.stop = new Stop({ scope: this.uri })
+  }
+
+  id() { return this._id }
+  key() { return this._id }
+
+  toPayload() {
+    const { id, base_name, name, status, cpu, ram } = this
+    return { id, base_name, name, status, cpu: cpu.toJS(), ram: ram.toJS() }
+  }
+}

--- a/lib/resources/entities/log-entry.js
+++ b/lib/resources/entities/log-entry.js
@@ -1,0 +1,8 @@
+import uuid from 'uuid'
+import { Record } from 'immutable'
+
+const entrySchema = { usage: 0, limit: 0 }
+export default class Meter extends Record(entrySchema) {
+  constructor(body) { super({ body }) }
+  toPayload() { return {} }
+}

--- a/lib/resources/entities/meter-spec.js
+++ b/lib/resources/entities/meter-spec.js
@@ -1,0 +1,14 @@
+import Immutable from 'immutable'
+import { kebabCase } from 'lodash'
+import Meter from './meter'
+
+describe("Instance", () => {
+  describe("initializing", () => {
+    const usage = 0
+    const limit = 1
+    const meter = new Meter({ usage, limit })
+
+    it('responds to usage', () => expect(meter.usage).to.equal(usage))
+    it('responds to limit', () => expect(meter.limit).to.equal(limit))
+  })
+})

--- a/lib/resources/entities/meter.js
+++ b/lib/resources/entities/meter.js
@@ -1,0 +1,5 @@
+import uuid from 'uuid'
+import { Record } from 'immutable'
+
+const meterSchema = { usage: 0, limit: 0 }
+export default class Meter extends Record(meterSchema) { }

--- a/lib/resources/entities/release-spec.js
+++ b/lib/resources/entities/release-spec.js
@@ -88,10 +88,23 @@ describe("Release", () => {
     })
   })
 
-  describe("key", () => {
-    const name = "Mega Release Prime"
+  describe("instances", () => {
+    const appName = 'App Name'
+    const componentName = 'Component Name'
     const timestamp = 105125018
-    const release = new Release({ name, timestamp })
+    const release = new Release({ appName, componentName, timestamp })
+    const appUri = `/api/v0/apps/${kebabCase(appName)}`
+    const componentUri = `${appUri}/components/${kebabCase(componentName)}`
+    const route = `${componentUri}/releases/${timestamp}/instances`
+
+    it("is a client with a release-specific uri", () => {
+      expect(release.instances.route).to.equal(route)
+    })
+  })
+
+  describe("key", () => {
+    const timestamp = 105125018
+    const release = new Release({ timestamp })
 
     it("returns the timestamp", () => {
       expect(release.key()).to.equal(release.timestamp)

--- a/lib/resources/entities/release.js
+++ b/lib/resources/entities/release.js
@@ -3,6 +3,7 @@ import { fromJS, Record } from 'immutable'
 import { kebabCase } from 'lodash'
 import App from './app'
 import Component from './component'
+import Instances from '../instances'
 
 const releaseSchema = {
   containers: [],
@@ -47,8 +48,9 @@ export default class Release extends Record(releaseSchema) {
     })
 
     this.app = new App({ name: appName })
-    this.component = new Component({ name: appName, appName })
+    this.component = new Component({ name: componentName, appName })
     this.uri = `${this.component.uri}/releases/${this.timestamp}`
+    this.instances = new Instances({ scope: this.uri })
   }
 
   id() { return this.tags.get('id') }

--- a/lib/resources/instances-spec.js
+++ b/lib/resources/instances-spec.js
@@ -1,0 +1,18 @@
+import Instance from './entities/instance'
+import Instances from './instances'
+
+describe("Instances client", () => {
+  const client = new Instances({ client: mockClient(Instance) })
+
+  describe("get", () => {
+    it("returns an instance", () => {
+      expect(client.get(0)).to.eventually.be.an.instanceof(Instance)
+    })
+  })
+
+  describe("fetch", () => {
+    it("returns a list", () => {
+      expect(client.fetch()).to.eventually.be.an.instanceof(Array)
+    })
+  })
+})

--- a/lib/resources/instances.js
+++ b/lib/resources/instances.js
@@ -1,0 +1,21 @@
+import ResourceClient from './resource-client'
+import Instance from './entities/instance'
+
+const composeApi = ({ client, scope }) => {
+  const api = new ResourceClient({ client })
+
+  api.route = `${scope}/instances`
+  api.resource = Instance
+
+  return api
+}
+
+export default class Instances {
+  constructor({ client, scope }) {
+    const api = composeApi({ client, scope })
+
+    this.fetch = api.fetch
+    this.get = api.get
+    this.route = api.route
+  }
+}

--- a/lib/resources/log-spec.js
+++ b/lib/resources/log-spec.js
@@ -1,0 +1,13 @@
+import Instance from './entities/instance'
+import Log from './log'
+
+describe("Log instance client", () => {
+  const client = new Log({ client: mockClient(Instance) })
+
+  describe("fetch", () => {
+    it("returns an Array", () => {
+      const promise = client.fetch()
+      expect(promise).to.eventually.be.an.instanceof(Array)
+    })
+  })
+})

--- a/lib/resources/log.js
+++ b/lib/resources/log.js
@@ -1,0 +1,20 @@
+import ResourceClient from './resource-client'
+import LogEntry from './entities/log-entry'
+
+const composeApi = ({ client, scope }) => {
+  const api = new ResourceClient({ client })
+
+  api.route = `${scope}/log`
+  api.resource = LogEntry
+
+  return api
+}
+
+export default class Log {
+  constructor({ client, scope }) {
+    const api = composeApi({ client, scope })
+
+    this.fetch = api.fetch
+    this.route = api.route
+  }
+}

--- a/lib/resources/start-spec.js
+++ b/lib/resources/start-spec.js
@@ -1,0 +1,13 @@
+import Instance from './entities/instance'
+import Start from './start'
+
+describe("Start client", () => {
+  const client = new Start({ client: mockClient(Instance) })
+
+  describe("create", () => {
+    it("returns a instance", () => {
+      const promise = client.create({})
+      expect(promise).to.eventually.be.an.instanceof(Instance)
+    })
+  })
+})

--- a/lib/resources/start.js
+++ b/lib/resources/start.js
@@ -1,0 +1,20 @@
+import ResourceClient from './resource-client'
+import Instance from './entities/instance'
+
+const composeApi = ({ client, scope }) => {
+  const api = new ResourceClient({ client })
+
+  api.route = `${scope}/start`
+  api.resource = Instance
+
+  return api
+}
+
+export default class Start {
+  constructor({ client, scope }) {
+    const api = composeApi({ client, scope })
+
+    this.create = api.create
+    this.route = api.route
+  }
+}

--- a/lib/resources/stop-spec.js
+++ b/lib/resources/stop-spec.js
@@ -1,0 +1,13 @@
+import Instance from './entities/instance'
+import Stop from './stop'
+
+describe("Stop instance client", () => {
+  const client = new Stop({ client: mockClient(Instance) })
+
+  describe("create", () => {
+    it("returns a instance", () => {
+      const promise = client.create({ })
+      expect(promise).to.eventually.be.an.instanceof(Instance)
+    })
+  })
+})

--- a/lib/resources/stop.js
+++ b/lib/resources/stop.js
@@ -1,0 +1,20 @@
+import ResourceClient from './resource-client'
+import Instance from './entities/instance'
+
+const composeApi = ({ client, scope }) => {
+  const api = new ResourceClient({ client })
+
+  api.route = `${scope}/stop`
+  api.resource = Instance
+
+  return api
+}
+
+export default class Stop {
+  constructor({ client, scope }) {
+    const api = composeApi({ client, scope })
+
+    this.create = api.create
+    this.route = api.route
+  }
+}


### PR DESCRIPTION
The last piece of the API continuity, instances, had gone incomplete for
a good amount of time.  This commit changes that, by introducing the
following client domains:

* Instances, for fetching instance information
* Stop, Start, and Log, for interacting with specific instances