### PR TITLE
Rename Component Releases button "Deploy"

### DIFF
--- a/lib/apps/AppView.component.js
+++ b/lib/apps/AppView.component.js
@@ -3,6 +3,7 @@ import App from './App.container'
 import ContextHeader from '../elements/ContextHeader.component'
 import ContextTitle from '../elements/ContextTitle.component'
 import ContextMenu from '../elements/ContextMenu.component'
+import ContextFooter from '../elements/ContextFooter.component'
 import DestroyButton from '../elements/DestroyButton.component'
 
 const AppView = ({ app, deleteApp, opacity }) =>
@@ -13,14 +14,18 @@ const AppView = ({ app, deleteApp, opacity }) =>
       </ContextTitle>
 
       <ContextMenu>
-        <DestroyButton onClick={ deleteApp } isAction={ true }>
-          Destroy
-        </DestroyButton>
       </ContextMenu>
     </ContextHeader>
+
     <div>
       { app && <App app={ app } /> }
     </div>
+
+    <ContextFooter>
+      <DestroyButton onClick={ deleteApp } isAction={ true } className='small'>
+        Delete App
+      </DestroyButton>
+    </ContextFooter>
   </div>
 
 AppView.propTypes = {

--- a/lib/components/ComponentDetail.component.js
+++ b/lib/components/ComponentDetail.component.js
@@ -3,6 +3,7 @@ import ActionButton from '../elements/ActionButton.component'
 import Column from '../elements/Column.component'
 import ContextHeader from '../elements/ContextHeader.component'
 import ContextMenu from '../elements/ContextMenu.component'
+import ContextFooter from '../elements/ContextFooter.component'
 import ContextOverview from '../elements/ContextOverview.component'
 import ContextTitle from '../elements/ContextTitle.component'
 import DestroyButton from '../elements/DestroyButton.component'
@@ -103,12 +104,8 @@ export default class ComponentDetail extends React.Component {
           <ContextMenu>
             <ReleasesDiff app={ app } component={ component } />
 
-            <DestroyButton onClick={ destroy } isAction={ true }>
-              Destroy
-            </DestroyButton>
-
             <ActionButton onClick={ goToReleases } isAction={ true }>
-              Releases
+              Deploy
             </ActionButton>
           </ContextMenu>
         </ContextHeader>
@@ -128,6 +125,12 @@ export default class ComponentDetail extends React.Component {
         </ComponentDetailResources>
 
         <Instances component={ component } app={ app } />
+
+        <ContextFooter>
+          <DestroyButton onClick={ destroy } isAction={ true } className='small'>
+            Delete Component
+          </DestroyButton>
+        </ContextFooter>
       </div>
     )
   }

--- a/lib/elements/ContextFooter.component.js
+++ b/lib/elements/ContextFooter.component.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const ContextFooter = ({ children, className }) =>
+  <footer className={ `context-footer ${className}` }>
+    { children }
+  </footer>
+
+ContextFooter.propTypes = { children: React.PropTypes.node }
+
+
+export default ContextFooter

--- a/lib/elements/DestroyButton.component.js
+++ b/lib/elements/DestroyButton.component.js
@@ -1,14 +1,14 @@
 import React from 'react'
 
-const classes = ({ isAction, hasGlyph, isTransparent }) =>
-  `${backgrounds(isTransparent)} ${glyphs(hasGlyph)} ${actions(isAction)}`
+const classes = ({ isAction, hasGlyph, isTransparent, className }) =>
+  `${backgrounds(isTransparent)} ${glyphs(hasGlyph)} ${actions(isAction)} ${className}`
 
 const actions = isAction => isAction ? `glyph-x-action-color` : `glyph-x`
 const backgrounds = isTransparent => isTransparent ? `transparent` : ``
 const glyphs = noGlyph => noGlyph ? `` : `with-glyph`
 
-const DestroyButton = ({ isAction, onClick, children }) =>
-  <button onClick={ onClick } className={ classes({ isAction }) }>
+const DestroyButton = ({ isAction, onClick, children, className }) =>
+  <button onClick={ onClick } className={ classes({ isAction, className }) }>
     { children }
   </button>
 

--- a/lib/registries/Registries.component.js
+++ b/lib/registries/Registries.component.js
@@ -23,7 +23,7 @@ class Registries extends React.Component {
         <ContextHeader className='table-row'>
           <h3>Docker Repositories</h3>
           <ContextMenu>
-            <ActionButton onClick={ newRegistry } isAction={ true }>
+            <ActionButton onClick={ newRegistry } isAction={ true } className="transparent">
               New
             </ActionButton>
           </ContextMenu>

--- a/lib/styles/pages/_layout.scss
+++ b/lib/styles/pages/_layout.scss
@@ -77,12 +77,25 @@ body {
   @include row();
 
   h3 {
-    @include span-columns(4);
+    @include span-columns(6);
   }
 
   .context-menu {
     text-align: right;
-    @include span-columns(8);
+    @include span-columns(6);
+  }
+}
+
+.context-footer {
+  text-align: left;
+  margin: 2em 0;
+  padding: 1em 0;
+  border-top: 1px solid $border-dark;
+  @include row();
+
+  .context-menu {
+    text-align: right;
+    @include span-columns(6);
   }
 }
 


### PR DESCRIPTION
THe Component "Releases" button wasn't very intention revealing, so
this commit renames it "Deploy."

After the rename "Deploy" and "Destroy" buttons were just too similar
to each other, so this commit also moves "Destroy" buttons to a new
ContextFooter element and renames them "Delete [Context]" for both
Components and Apps.

<img width="1240" alt="screen shot 2016-05-10 at 5 41 31 pm" src="https://cloud.githubusercontent.com/assets/676428/15165872/aa3b17e2-16d6-11e6-934c-33ce3017d0e4.png">
