### PR TITLE
Improve test coverage measurement.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gem
 .DS_Store
 .sass-cache/
+/coverage/
 /notes/
 /node_modules/
 /tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ script:
   - docker build -t $REPO:$TAG .
 
 after_success:
-  - istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --opts mocha.opts && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js --verbose && rm -rf ./coverage
+  - node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --opts mocha.opts --bail  && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js --verbose && rm -rf ./coverage
   - docker push $REPO:$TAG

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "serve": "npm run build && node server.js",
     "dev": "node server.js",
     "tdd": "mocha --opts mocha.opts --watch --watch-extensions js",
-    "test": "mocha --opts mocha.opts"
+    "test": "mocha --opts mocha.opts",
+    "coverage": "node ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- --opts mocha.opts --bail"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.1",
@@ -57,6 +58,7 @@
     "immutable": "^3.7.6",
     "immutablediff": "^0.4.2",
     "isomorphic-fetch": "^2.2.1",
+    "istanbul": "^1.0.0-alpha",
     "json-server": "^0.8.10",
     "lodash": "^4.6.1",
     "mocha": "^2.3.4",


### PR DESCRIPTION
Previously the test coverage Istanbul was providing had been throttled
by the local use of Babel (which Istanbul didn't understand).  This
commit updates Istanbul to the latest 1.0 alpha and performs the
coverage runner a little differently in order to achieve more accurate
results.