### PR TITLE
Container detail buttons don't submit form.

### DIFF
--- a/lib/containers/ManageCommands.component.js
+++ b/lib/containers/ManageCommands.component.js
@@ -14,7 +14,12 @@ const CommandForm = ({ commands, command, index }) =>
                      value={ command } />
     </Column>
     <Column className='text-right' size={ 1 }>
-      <DestroyIcon onClick={ () => commands.removeField(index) } />
+      <DestroyIcon onClick={
+        event => {
+          event.preventDefault()
+          commands.removeField(index)
+        }
+      } />
     </Column>
   </Line>
 
@@ -40,7 +45,12 @@ const ManageCommands = ({ commands }) =>
     }
 
     <Line>
-      <AddIcon onClick={ () => commands.addField() } />
+      <AddIcon onClick={
+        event => {
+          event.preventDefault()
+          commands.addField()
+        }
+      } />
     </Line>
   </Fieldset>
 

--- a/lib/containers/ManageEnv.component.js
+++ b/lib/containers/ManageEnv.component.js
@@ -25,7 +25,12 @@ const VariableForm = ({ env, index, variable }) =>
                      value={ variable.value } />
     </Column>
     <Column className='text-right' size={ 1 }>
-      <DestroyIcon onClick={ () => env.removeField(index) } />
+      <DestroyIcon onClick={
+        event => {
+          event.preventDefault()
+          env.removeField(index)
+        }
+      } />
     </Column>
   </Line>
 
@@ -49,7 +54,12 @@ const ManageEnv = ({ env }) =>
     }
 
     <Line>
-      <AddIcon onClick={ () => env.addField() } />
+      <AddIcon onClick={
+        event => {
+          event.preventDefault()
+          env.addField()
+        }
+      } />
     </Line>
   </Fieldset>
 

--- a/lib/containers/ManageMounts.component.js
+++ b/lib/containers/ManageMounts.component.js
@@ -25,7 +25,12 @@ const MountForm = ({ index, mount, mounts }) =>
                      value={ mount.path } />
     </Column>
     <Column className='text-right' size={ 1 }>
-      <DestroyIcon onClick={ () => mounts.removeField(index) } />
+      <DestroyIcon onClick={
+        event => {
+          event.preventDefault()
+          mounts.removeField(index)
+        }
+      } />
     </Column>
   </Line>
 
@@ -49,7 +54,12 @@ const ManageMounts = ({ mounts }) =>
     }
 
     <Line>
-      <AddIcon onClick={ () => mounts.addField() } />
+      <AddIcon onClick={
+        event => {
+          event.preventDefault()
+          mounts.addField()
+        }
+      } />
     </Line>
   </Fieldset>
 

--- a/lib/containers/ManagePorts.component.js
+++ b/lib/containers/ManagePorts.component.js
@@ -41,7 +41,12 @@ const PortForm = ({ index, port, ports }) =>
         </EasyLabel>
       </Column>
       <Column className='text-right' size={ 1 }>
-        <DestroyIcon onClick={ () => ports.removeField(index) } />
+        <DestroyIcon onClick={
+          event => {
+            event.preventDefault()
+            ports.removeField(index)
+          }
+        } />
       </Column>
     </TableRow>
     {
@@ -83,7 +88,12 @@ const ManagePorts = ({ ports }) =>
     }
 
     <Line>
-      <AddIcon onClick={ () => ports.addField() } />
+      <AddIcon onClick={
+        event => {
+          event.preventDefault()
+          ports.addField()
+        }
+      } />
     </Line>
   </Fieldset>
 


### PR DESCRIPTION
A previous refactor had exposed some button elements within the
container form without an explicit `preventDefault` call on those
buttons.  Of course, when there's a button within a form then the
default behavior is to submit the form.

This commit explicitly disables all default button behavior within the
container form detail configuration components.

closes https://github.com/supergiant/supergiant-dashboard/issues/121