### PR TITLE
Correctly partition components on app name.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ import { syncHistoryWithStore } from 'react-router-redux'
 import Routes from './routes'
 import store from './store'
 import { starfield } from './visuals/starfield'
-import * as Resources from './resources'
 
 let element = document.getElementById('app')
 let router  = state => state.get('routing').toJS()
@@ -18,8 +17,6 @@ let content = (
     <Router history={ history } routes={ Routes } />
   </Provider>
 )
-
-window.Resources = Resources
 
 starfield()
 render(content, element)

--- a/lib/selectors.js
+++ b/lib/selectors.js
@@ -112,9 +112,12 @@ export function createAppComponentsSelector(app) {
   return createSelector(
     getComponents,
     components => {
-      return components.filter(
-        component => component.get('id').includes(app.get('name'))
-      ).toList()
+      return components.filter(component => {
+        const id = component.get('id')
+        const name = component.get('name')
+
+        return id.replace(`-${name}`, '') === app.name
+      }).toList()
     }
   )
 }


### PR DESCRIPTION
The previous method of approaching component / app sorting was a naive
approach.  It presumed that apps would have more or less distinct names.
That hasn't really been the case, however - so in instances where the
app names were very similar, a given component would appear in multiple
places.

This commit makes a little more of an intelligent guess out of the whole
thing - but ultimately what we really need to do in the long term will
be to organize components in a much more distinct way.  Either we can
give them a better keying interface on the back end or we can invent one
custom to the front-end using the tags feature.