### PR TITLE
Add `secret_type` support for repos.

### DIFF
--- a/lib/registries/CreateRegistry.container.js
+++ b/lib/registries/CreateRegistry.container.js
@@ -60,7 +60,7 @@ function mapDispatchToProps(dispatch, props) {
         dispatch(add('error', Reflect.get(errors, error)))
       }
     } else {
-      dispatch(create({ ...rest, key }))
+      dispatch(create({ ...rest, key, secret_type: 'dockerconfigjson' }))
     }
   }
 

--- a/lib/registries/registries.entity.js
+++ b/lib/registries/registries.entity.js
@@ -11,25 +11,26 @@ export const saveRegistry = registry =>
   new ResourceClient(registryRoute()).create(registry.toJS())
 
 export class Registry {
-  static from({ name, key }) {
-    return new Registry({ name, key })
+  static from({ name, key, secret_type }) {
+    return new Registry({ name, key, secret_type })
   }
 
-  static create({ name, key }) {
-    return new Registry({ name, key })
+  static create({ name, key, secret_type }) {
+    return new Registry({ name, key, secret_type })
   }
 
-  constructor({ name, key }) {
+  constructor({ name, key, secret_type }) {
     this.name = name
     this.key = key
+    this.secret_type = secret_type
   }
 
   id() { return this.name }
   toJS() { return this.toMap().toJS() }
 
   toMap() {
-    let { name, key } = this
-    return fromJS({ name, key })
+    let { name, key, secret_type } = this
+    return fromJS({ name, key, secret_type })
   }
 }
 


### PR DESCRIPTION
We've encountered a flaw in the API which requires a bit of an interface
change: repos were assuming a specific format of secret type which
Kubernetes requires be explicitly set.  In this commit, we update the
dashboard to supply this field, `secret_type`, on repo creation.