### PR TITLE
App creation fix

### DIFF
--- a/lib/apps/apps.sagas.js
+++ b/lib/apps/apps.sagas.js
@@ -40,12 +40,12 @@ export function* getApp(getState, { id }) {
 
 export function* createApp(getState, { params }) {
   try {
-    let app = yield call([ Client, Client.create(params) ])
+    let app = yield call([ Client, Client.create ], params)
 
     yield fork(infoMessages, `Created '/${app.name}'`)
     yield put(push(`/`))
   } catch (error) {
-    yield fork(errorMessages, error)
+    yield fork(errorMessages, String(error))
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "redux": "^3.3.0",
     "redux-devtools": "^3.1.0",
     "redux-devtools-dock-monitor": "^1.0.1",
-    "redux-form": "^4.2.0",
+    "redux-form": "^5.2.0",
     "redux-saga": "^0.9.5",
     "redux-slider-monitor": "^1.0.2",
     "reselect": "^2.2.1",


### PR DESCRIPTION
This PR does two things:

## Create app creation saga

In a fit of derp, a reimplementation of app creation was rolled out
which had a flawed invocation of Redux Saga's `call` effect.  Because it
was invoking a function in the flawed call, the record was still being
created - but then it was immediately throwing an error.

This pull request fixes that behavior.

## Update Redux Form

Redux form was triggering an invariant violation error due to React's update to version 15.  The newer version of Redux form doesn't cause the same invariant violation.
