### PR TITLE
Support port-per-instance on releases.

### DIFF
--- a/lib/containers/CreateContainer.container.js
+++ b/lib/containers/CreateContainer.container.js
@@ -19,6 +19,7 @@ const fields = [
   'ports[].protocol',
   'ports[].number',
   'ports[].public',
+  'ports[].per_instance',
   'ports[].external_number',
   'ports[].entrypoint_domain',
   'env[].name',

--- a/lib/containers/ManagePorts.component.js
+++ b/lib/containers/ManagePorts.component.js
@@ -30,7 +30,31 @@ const PortForm = ({ index, port, ports }) =>
                        prompt='port protocol'
                        value={ port.protocol } />
       </Column>
-      <Column size={ 3 }>
+      <Column size={ 3 } />
+      <Column className='text-right' size={ 1 }>
+        <DestroyIcon onClick={
+          event => {
+            event.preventDefault()
+            ports.removeField(index)
+          }
+        } />
+      </Column>
+    </TableRow>
+    <TableRow>
+      <Column size={ 11 }>
+        <EasyLabel>
+          <FeedbackInput type='checkbox'
+                         prompt=''
+                         value={ port.per_instance } />
+          &nbsp;
+          &nbsp;
+          Expose on every instance?
+        </EasyLabel>
+      </Column>
+      <Column size={ 1 }/>
+    </TableRow>
+    <TableRow>
+      <Column size={ 11 }>
         <EasyLabel>
           <FeedbackInput type='checkbox'
                          prompt=''
@@ -40,14 +64,7 @@ const PortForm = ({ index, port, ports }) =>
           Public?
         </EasyLabel>
       </Column>
-      <Column className='text-right' size={ 1 }>
-        <DestroyIcon onClick={
-          event => {
-            event.preventDefault()
-            ports.removeField(index)
-          }
-        } />
-      </Column>
+      <Column size={ 1 }/>
     </TableRow>
     {
       port.public.value && (

--- a/lib/instances/Instance.component.js
+++ b/lib/instances/Instance.component.js
@@ -6,6 +6,27 @@ import CpuMeter from '../elements/CpuMeter.component'
 import RamMeter from '../elements/RamMeter.component'
 
 export default class Instance extends React.Component {
+  externalAddresses() {
+    const externals = this.props.instance.getIn(['addresses', 'external'])
+
+    if (externals && externals.count() > 0) {
+      return(
+        <div>
+          <div>External addresses:</div>
+          {
+            externals.map((external, index) => (
+              <p>
+                <a href={ external.get('address') } target='_blank'>
+                  { external.get('address') }
+                </a>
+              </p>
+            ))
+          }
+        </div>
+      )
+    }
+  }
+
   render() {
     const { instance } = this.props
     const opacity = instance.get('status') === 'STOPPED' ? 0.5 : 1
@@ -29,6 +50,9 @@ export default class Instance extends React.Component {
             <RamMeter usage={ instance.getIn(['ram', 'usage']) }
                       limit={ instance.getIn(['ram', 'limit']) } />
           </Row>
+
+          { this.externalAddresses() }
+
         </Resource>
       </span>
     )


### PR DESCRIPTION
This commit adds two features:

* You may now toggle a "per instance" check on ports when building a
  release.  As it's deployed, each instance will be given a public
  facing port.
* Externally facing containers show their instance addresses on the
  component detail page.  This is a convenience link which will let you
  hop to a supported component straight-away.